### PR TITLE
🔒 [security fix] Limit CRUX list download size

### DIFF
--- a/noisy.py
+++ b/noisy.py
@@ -54,6 +54,7 @@ DNS_CACHE_TTL = 120
 # ---- NETWORK ----
 REQUEST_TIMEOUT = 15
 MAX_RESPONSE_BYTES = 512 * 1024
+MAX_CRUX_LIST_BYTES = 50 * 1024 * 1024
 MAX_HEADER_SIZE = 32 * 1024
 
 # ---- RUNTIME ----
@@ -608,7 +609,17 @@ async def fetch_crux_top_sites(
         if resp.status >= 400:
             logging.error("CRUX fetch failed with status %s", resp.status)
             return []
-        data = await resp.read()
+
+        chunks = []
+        total_read = 0
+        async for chunk in resp.content.iter_chunked(65536):
+            chunks.append(chunk)
+            total_read += len(chunk)
+            if total_read >= MAX_CRUX_LIST_BYTES:
+                logging.warning("CRUX list limit reached (%d bytes); truncating", MAX_CRUX_LIST_BYTES)
+                break
+        data = b"".join(chunks)
+
     csv_text = gzip.decompress(data).decode()
     reader = csv.DictReader(csv_text.splitlines())
     sites, seen = [], set()


### PR DESCRIPTION
This PR fixes a security vulnerability where the `fetch_crux_top_sites` function would read the entire response from the CRUX top lists URL into memory without any size constraints.

### 🎯 What:
Fixed an unbounded response read vulnerability in the CRUX list fetching logic.

### ⚠️ Risk:
An attacker who can control or influence the response from `raw.githubusercontent.com` could send an extremely large file, causing the crawler to consume all available memory and crash (Denial of Service).

### 🛡️ Solution:
Implemented a size-limited chunked read:
1.  Defined `MAX_CRUX_LIST_BYTES = 50 * 1024 * 1024` (50MB) as a safe upper bound.
2.  Modified `fetch_crux_top_sites` to use `resp.content.iter_chunked(65536)` to download data in chunks.
3.  The loop breaks if `total_read >= MAX_CRUX_LIST_BYTES`, effectively bounding memory usage.
4.  Added a warning log when truncation occurs.


---
*PR created automatically by Jules for task [6149386830116316543](https://jules.google.com/task/6149386830116316543) started by @madereddy*