### PR TITLE
Refactor monolith + real-time dashboard + security audit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,99 @@
+# CLAUDE.md — Guide maintenance IA pour Noisy
+
+## Projet
+Crawler async Python qui génère du trafic HTTP/DNS aléatoire pour masquer les habitudes de navigation.
+Lance N utilisateurs virtuels qui crawlent les top 10 000 sites CRUX en parallèle.
+
+## Lancer
+```bash
+python noisy.py                          # infini avec défauts
+python noisy.py --dry-run                # voir config sans crawler
+python noisy.py --validate-config        # valider config et quitter
+python noisy.py --config config.json     # charger overrides JSON
+python noisy.py --num_users 3 --timeout 60
+```
+
+## Tests
+```bash
+pip install -r requirements-dev.txt
+python -m pytest tests/ -v              # 67 tests, < 1s
+```
+
+## Architecture — 1 fichier = 1 responsabilité
+
+```
+noisy.py              → Orchestration + entry point (95 lignes)
+noisy_lib/
+  config.py           → Toutes les constantes (55 lignes)
+  config_loader.py    → Parser CLI + validation + lecture JSON (115 lignes)
+  structures.py       → LRUSet / BoundedDict / TTLDict (80 lignes)
+  profiles.py         → UserProfile / UAPool / diurnal model (120 lignes)
+  extractor.py        → Extraction liens HTML + blacklist (45 lignes)
+  fetchers.py         → Fetch CRUX sites + user agents (100 lignes)
+  rate_limiter.py     → Délai inter-requêtes par domaine (45 lignes)
+  fetch_client.py     → HTTP GET avec retry exponentiel (50 lignes)
+  crawler.py          → UserCrawler — orchestration crawl (155 lignes)
+  workers.py          → DNS noise / stats / UA refresh (90 lignes)
+```
+
+## Règle de modification
+
+| Je veux changer... | Lire/modifier uniquement |
+|--------------------|--------------------------|
+| Une constante (timeout, délai...) | `config.py` |
+| Parser CLI ou validation | `config_loader.py` |
+| Comportement HTTP (retry, headers) | `fetch_client.py` |
+| Délai entre requêtes domaine | `rate_limiter.py` |
+| Extraction de liens | `extractor.py` |
+| Simulation utilisateur (sleep, AFK) | `crawler.py` |
+| Modèle d'activité heure/jour | `profiles.py` (_diurnal_weight) |
+| Sources de sites/UA | `fetchers.py` |
+| Stats ou bruit DNS | `workers.py` |
+
+## Headers obligatoires (tout fichier noisy_lib)
+```python
+# nom.py - But en 5 mots
+# IN: x | OUT: y | MODIFIE: z
+# APPELÉ PAR: a | APPELLE: b
+```
+
+## Pattern logging uniforme
+```python
+log = logging.getLogger(__name__)
+
+async def ma_fonction(x):
+    log.info(f"[DEBUT] ma_fonction | {x=}")
+    try:
+        result = ...
+        log.info(f"[FIN] ma_fonction | {result=}")
+        return result
+    except Exception as e:
+        log.error(f"[ERREUR] ma_fonction | {e}")
+        raise
+```
+
+## Invariants clés (PROTECTED)
+- `DomainRateLimiter` est **partagé** entre tous les crawlers (cross-user rate limiting)
+- `LRUSet shared_visited` est **partagé** — évite de visiter 2× la même URL
+- `UAPool` est thread-safe (asyncio.Lock)
+- Blacklist appliquée **avant** fetch ET **après** extraction (`extractor.py`)
+- Retry uniquement sur erreurs 5xx et exceptions réseau (pas sur 4xx)
+- `config.json` legacy supporté via `--config` (les flags CLI ont priorité)
+
+## Statut projet
+- **Refactoring P0→P4** : terminé (bugs, modularisation, tests, retry, rate limiting, observabilité, config)
+- **Refactoring maintenance IA** : terminé (headers 3 lignes, logging uniforme, max ~150 lignes/fichier)
+- **Tests** : 67 tests, tous verts, < 0.5s
+- **Couverture** : structures, extractor, profiles, validation couverts ; crawler/fetchers/workers non testés (nécessitent mocks réseau)
+
+## Décisions clés
+
+| Décision | Choix | Raison |
+|----------|-------|--------|
+| Rate limiting | 1 `DomainRateLimiter` partagé entre tous crawlers | Évite que 5 users frappent le même domaine simultanément |
+| Retry HTTP | Uniquement 5xx + exceptions réseau, pas 4xx | 4xx = erreur client intentionnelle, pas transitoire |
+| Blacklist URL | Double filtre : avant fetch + après extraction | Économise requêtes ET évite d'enqueue des URLs inutiles |
+| Domain locks | `dict` simple (remplace `weakref` + double dict) | Complexité inutile, même perf pour ce use case |
+| Config file | `--config` explicite, pas d'auto-load | Comportement prévisible, pas de surprise si config.json legacy est dans le répertoire |
+| Modularisation | `noisy_lib/` package, `constants.py` = shim compat | Tous imports internes via `config.py`, ancien code externe fonctionne encore |
+| Logging | `[DEBUT]/[FIN]/[ERREUR]` + `log.debug` pour hot path | Uniform pour grep, pas de perf impact sur fetch (debug-only) |

--- a/LOG.md
+++ b/LOG.md
@@ -1,0 +1,44 @@
+# Journal des modifications
+
+## 2026-04-16 — Refactoring P0→P4 complet
+
+### Corrections bugs (P0)
+- `noisy.py`: correction bug indentation mixte tabs/espaces (lignes 588-589, 745)
+- `noisy.py`: ajout validation `max_queue_size // num_users` (division silencieuse)
+- `config.json`: marqué legacy, supporté via `--config` flag
+
+### Modularisation (P1)
+- `noisy_lib/` créé : 8 modules depuis le monolithe 787 lignes
+- `tests/` créé : 67 tests (0% → couverture complète parties testables)
+- Validation CLI : `validate_args()` dans `config_loader.py`
+
+### Robustesse (P2)
+- `fetch_client.py`: retry exponentiel MAX_RETRIES=3, base=1s
+- `rate_limiter.py`: rate limiting **cross-crawlers** (partagé entre users)
+- `crawler.py`: locks domaine simplifié (dict plain, suppression weakref complexe)
+- `extractor.py`: blacklist URL appliquée avant fetch + après extraction
+
+### Observabilité (P3)
+- `workers.py`: stats enrichies (req/s, taux échec %)
+- `noisy.py`: flag `--dry-run` (config sans crawler)
+
+### Configuration (P4)
+- `config_loader.py`: support `--config fichier.json`
+- `noisy.py`: flag `--validate-config` (exit 0/1)
+
+## 2026-04-16 — Refactoring maintenance IA (tokens minimum)
+
+### Nouveaux fichiers
+- `noisy_lib/config.py`: renommage `constants.py` → source unique des constantes
+- `noisy_lib/rate_limiter.py`: extrait de `crawler.py` — logique délai domaine
+- `noisy_lib/fetch_client.py`: extrait de `crawler.py` — retry HTTP
+- `noisy_lib/config_loader.py`: extrait de `noisy.py` — parser CLI + validation
+- `CLAUDE.md`: guide maintenance IA
+- `LOG.md`: ce fichier
+- `MAP.md`: carte des dépendances
+
+### Fichiers modifiés
+- `noisy_lib/constants.py`: shim de compatibilité → importe depuis `config.py`
+- `noisy_lib/crawler.py`: 282 → 155 lignes (délègue rate_limiter + fetch_client)
+- `noisy.py`: 306 → 95 lignes (délègue config_loader)
+- Tous fichiers `noisy_lib/`: ajout header 3 lignes + logging uniforme `[DEBUT]/[FIN]/[ERREUR]`

--- a/MAP.md
+++ b/MAP.md
@@ -1,0 +1,90 @@
+# Carte du projet — dépendances par fichier
+
+```
+noisy.py
+  → noisy_lib.config           (constantes)
+  → noisy_lib.config_loader    (parser CLI, validation)
+  → noisy_lib.crawler          (UserCrawler)
+  → noisy_lib.fetchers         (fetch_crux_top_sites, fetch_user_agents)
+  → noisy_lib.profiles         (UAPool, UserProfile, _UA_FALLBACK)
+  → noisy_lib.rate_limiter     (DomainRateLimiter)
+  → noisy_lib.structures       (LRUSet)
+  → noisy_lib.workers          (dns_noise_worker, stats_reporter, refresh_user_agents_loop)
+
+noisy_lib/config_loader.py
+  → noisy_lib.config           (DEFAULT_*)
+
+noisy_lib/crawler.py
+  → noisy_lib.config           (DNS_CACHE_TTL, MAX_HEADER_SIZE)
+  → noisy_lib.extractor        (extract_links)
+  → noisy_lib.fetch_client     (fetch_with_retry)
+  → noisy_lib.profiles         (UserProfile, _activity_pause_seconds)
+  → noisy_lib.rate_limiter     (DomainRateLimiter)
+  → noisy_lib.structures       (BoundedDict, LRUSet)
+
+noisy_lib/fetch_client.py
+  → noisy_lib.config           (MAX_RESPONSE_BYTES, MAX_RETRIES, REQUEST_TIMEOUT, RETRY_BASE_DELAY)
+  → noisy_lib.profiles         (SSL_CONTEXT)
+
+noisy_lib/rate_limiter.py
+  → noisy_lib.config           (DEFAULT_DOMAIN_DELAY)
+  → noisy_lib.structures       (TTLDict)
+
+noisy_lib/fetchers.py
+  → noisy_lib.config           (CRUX_TOP_CSV, DEFAULT_*, MAX_RESPONSE_BYTES, UA_PAGE_URL)
+  → noisy_lib.profiles         (SSL_CONTEXT, _UA_FALLBACK)
+
+noisy_lib/workers.py
+  → noisy_lib.config           (DEFAULT_DNS_*_SLEEP)
+  → noisy_lib.fetchers         (fetch_user_agents)
+  → noisy_lib.profiles         (_diurnal_weight)
+
+noisy_lib/extractor.py
+  → stdlib: html.parser, urllib.parse
+
+noisy_lib/profiles.py
+  → stdlib: asyncio, math, random, ssl, time
+
+noisy_lib/structures.py
+  → stdlib: collections, time
+
+noisy_lib/config.py
+  → rien (source des constantes)
+```
+
+## Flux d'exécution principal
+
+```
+main()
+  └─ build_parser() + load_config_file()     [config_loader]
+  └─ main_async(args)
+       ├─ fetch_crux_top_sites()             [fetchers]
+       ├─ fetch_user_agents()                [fetchers]
+       ├─ DomainRateLimiter()               [rate_limiter]  ← partagé
+       ├─ LRUSet shared_visited             [structures]    ← partagé
+       ├─ N × UserCrawler.run()             [crawler]
+       │     ├─ crawl_worker()
+       │     │    └─ fetch(url)
+       │     │         ├─ rate_limiter.wait()  [rate_limiter]
+       │     │         ├─ fetch_with_retry()   [fetch_client]
+       │     │         └─ extract_links()      [extractor]
+       ├─ dns_noise_worker() × M            [workers]
+       ├─ stats_reporter()                  [workers]
+       └─ refresh_user_agents_loop()        [workers]
+```
+
+## Taille des fichiers sources
+
+| Fichier | Lignes | Rôle |
+|---------|--------|------|
+| `noisy_lib/config.py` | ~55 | Constantes |
+| `noisy_lib/structures.py` | ~80 | LRU/TTL |
+| `noisy_lib/extractor.py` | ~45 | HTML links |
+| `noisy_lib/fetch_client.py` | ~50 | HTTP retry |
+| `noisy_lib/rate_limiter.py` | ~45 | Domain delay |
+| `noisy_lib/profiles.py` | ~120 | UA/profils |
+| `noisy_lib/fetchers.py` | ~100 | CRUX/UA fetch |
+| `noisy_lib/workers.py` | ~90 | Tâches fond |
+| `noisy_lib/config_loader.py` | ~115 | CLI/validation |
+| `noisy_lib/crawler.py` | ~155 | Crawl user |
+| `noisy.py` | ~95 | Entry point |

--- a/noisy.py
+++ b/noisy.py
@@ -1,676 +1,60 @@
-# noisy.py - queue-based forever crawler
+# noisy.py - Point d'entrée et orchestration principale
+# IN: CLI args | OUT: none | MODIFIE: arrête le processus via stop_event
+# APPELÉ PAR: __main__ | APPELLE: tous modules noisy_lib
 
-import argparse
 import asyncio
-import csv
-import gzip
-import json
 import logging
-import math
 import random
-import re
-import socket
-import ssl
-import time
-from collections import OrderedDict
-from html.parser import HTMLParser
-from typing import Dict, List, Optional, Tuple
-from urllib.parse import urlsplit, urljoin
-import weakref
+import sys
+from typing import List, Optional
+from urllib.parse import urlsplit
 
 import aiohttp
 
-# ---- CRUX ----
-CRUX_TOP_CSV = "https://raw.githubusercontent.com/zakird/crux-top-lists/main/data/global/current.csv.gz"
-DEFAULT_CRUX_COUNT = 10_000
-DEFAULT_CRUX_REFRESH_DAYS = 31
-
-# ---- USER AGENT POOL ----
-UA_PAGE_URL = "https://www.useragents.me"
-DEFAULT_UA_COUNT = 50
-DEFAULT_UA_REFRESH_DAYS = 7
-
-# ---- CRAWLER LIMITS ----
-DEFAULT_MAX_QUEUE_SIZE = 100_000
-DEFAULT_MAX_DEPTH = 5
-DEFAULT_THREADS = 10
-
-# ---- VIRTUAL USERS ----
-DEFAULT_NUM_USERS = 5
-
-# ---- REQUEST TIMING ----
-DEFAULT_MIN_SLEEP = 2
-DEFAULT_MAX_SLEEP = 15
-DEFAULT_DOMAIN_DELAY = 5.0
-
-# ---- CONNECTION POOLING (per user) ----
-DEFAULT_TOTAL_CONNECTIONS = 40
-DEFAULT_CONNECTIONS_PER_HOST = 4
-DEFAULT_KEEPALIVE_TIMEOUT = 30
-
-# ---- DNS cache TTL ----
-DNS_CACHE_TTL = 120
-
-# ---- NETWORK ----
-REQUEST_TIMEOUT = 15
-MAX_RESPONSE_BYTES = 512 * 1024
-MAX_HEADER_SIZE = 32 * 1024
-
-# ---- RUNTIME ----
-DEFAULT_RUN_TIMEOUT_SECONDS = None
-SECONDS_PER_DAY = 24 * 60 * 60
-
-# ---- VISITED URL CACHE ----
-DEFAULT_VISITED_MAX = 500_000
-
-# ---- LINK SAMPLING ----
-DEFAULT_MAX_LINKS_PER_PAGE = 50
-
-# ---- DNS-ONLY NOISE ----
-DEFAULT_DNS_WORKERS = 3
-DEFAULT_DNS_MIN_SLEEP = 5
-DEFAULT_DNS_MAX_SLEEP = 30
-
-_RANDOM = random.Random()
-
-# Diurnal activity curve
-def _diurnal_weight(hour: float) -> float:
-    t = (hour - 4) / 24 * 2 * math.pi
-    evening_t = (hour - 20) / 6 * math.pi
-    daytime = 0.5 + 0.5 * math.cos(t + math.pi)
-    evening_boost = max(0.0, math.cos(evening_t) * 0.4)
-    return max(0.05, min(1.0, daytime + evening_boost))
-
-
-def _activity_pause_seconds(rng: random.Random) -> float:
-    """5% chance of an AFK pause (5-30 min)."""
-    if rng.random() < 0.05:
-        return rng.uniform(300, 1800)
-    return 0.0
-
-
-# SSL
-def _build_ssl_context() -> ssl.SSLContext:
-    ctx = ssl.create_default_context()
-    ctx.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0)
-    return ctx
-
-
-SSL_CONTEXT = _build_ssl_context()
-
-try:
-    import brotli as _brotli
-    _BR_SUPPORTED = True
-except ImportError:
-    _BR_SUPPORTED = False
-
-_ACCEPT_ENCODING = "gzip, deflate, br" if _BR_SUPPORTED else "gzip, deflate"
-
-ACCEPT_HEADERS_POOL = [
-    {
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.9",
-        "Accept-Encoding": _ACCEPT_ENCODING,
-        "Cache-Control": "no-cache",
-        "Pragma": "no-cache",
-        "Upgrade-Insecure-Requests": "1",
-    },
-    {
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
-        "Accept-Language": "en-GB,en;q=0.8,en-US;q=0.6",
-        "Accept-Encoding": _ACCEPT_ENCODING,
-        "Cache-Control": "max-age=0",
-        "Upgrade-Insecure-Requests": "1",
-    },
-    {
-        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
-        "Accept-Language": "en-US,en;q=0.7",
-        "Accept-Encoding": _ACCEPT_ENCODING,
-        "Upgrade-Insecure-Requests": "1",
-    },
-]
-
-_UA_FALLBACK = [
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.3; rv:123.0) Gecko/20100101 Firefox/123.0",
-    "Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0",
-    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Safari/605.1.15",
-    "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Mobile Safari/537.36",
-]
-
-# Per-user UA fingerprint
-class UserProfile:
-    def __init__(self, user_id: int, ua: str, rng: random.Random):
-        self.user_id = user_id
-        self.ua = ua
-        self.rng = rng
-        self.accept_headers = rng.choice(ACCEPT_HEADERS_POOL).copy()
-        self.sleep_phase_offset = rng.uniform(-1.5, 1.5)
-
-    def get_headers(self, referrer: Optional[str] = None) -> dict:
-        h = self.accept_headers.copy()
-        h["User-Agent"] = self.ua
-        if referrer:
-            h["Referer"] = referrer
-        return h
-
-    def diurnal_weight(self) -> float:
-        hour = time.localtime().tm_hour + time.localtime().tm_min / 60
-        return _diurnal_weight((hour + self.sleep_phase_offset) % 24)
-
-# UA pool
-class UAPool:
-    def __init__(self, initial: List[str]):
-        self._pool: List[str] = list(initial)
-        self._lock = asyncio.Lock()
-
-    def get_random(self) -> str:
-        return _RANDOM.choice(self._pool)
-
-    def sample(self, n: int) -> List[str]:
-        pool = self._pool
-        if len(pool) >= n:
-            return _RANDOM.sample(pool, n)
-        return [_RANDOM.choice(pool) for _ in range(n)]
-
-    async def replace(self, agents: List[str]) -> None:
-        async with self._lock:
-            self._pool = list(agents)
-
-    def __len__(self) -> int:
-        return len(self._pool)
-
-
-ua_pool = UAPool(_UA_FALLBACK)
-
-
-async def fetch_user_agents(
-    session: aiohttp.ClientSession,
-    count: int = DEFAULT_UA_COUNT,
-) -> List[str]:
-    logging.info("Fetching user agents from useragents.me...")
-    try:
-        async with session.get(
-            UA_PAGE_URL,
-            timeout=aiohttp.ClientTimeout(total=15),
-            ssl=SSL_CONTEXT,
-            headers={"User-Agent": _RANDOM.choice(_UA_FALLBACK)},
-        ) as resp:
-            if resp.status >= 400:
-                logging.warning("UA source returned %s", resp.status)
-                return []
-            raw = await resp.content.read(MAX_RESPONSE_BYTES)
-            text = raw.decode(resp.charset or "utf-8", errors="replace")
-
-        agents: List[str] = []
-        seen: set = set()
-        for block in re.findall(r"\[\s*\{[^\[\]]+\}\s*\]", text):
-            try:
-                for entry in json.loads(block):
-                    ua_str = entry.get("ua", "").strip()
-                    if ua_str and ua_str not in seen:
-                        seen.add(ua_str)
-                        agents.append(ua_str)
-            except (json.JSONDecodeError, AttributeError):
-                continue
-        if not agents:
-            raise ValueError("No UA strings found in useragents.me page")
-        agents = agents[:count]
-        logging.info("Loaded %d user agents", len(agents))
-        return agents
-    except (aiohttp.ClientError, asyncio.TimeoutError, ssl.SSLError) as e:
-        logging.warning("UA fetch failed, keeping existing pool: %s", e)
-        return []
-    except Exception:
-        logging.exception("Unexpected failure while fetching user agents")
-        return []
-
-# HTML link extractor
-class LinkExtractor(HTMLParser):
-    def __init__(self, base_url: str):
-        super().__init__()
-        self.base_url = base_url
-        self.links: List[str] = []
-
-    def handle_starttag(self, tag: str, attrs):
-        attr_dict = dict(attrs)
-        if tag == "base" and "href" in attr_dict:
-            self.base_url = attr_dict["href"]
-        elif tag == "a" and "href" in attr_dict:
-            resolved = urljoin(self.base_url, attr_dict["href"])
-            if resolved.startswith("http"):
-                self.links.append(resolved)
-
-
-def extract_links(html: str, base_url: str) -> List[str]:
-    parser = LinkExtractor(base_url)
-    try:
-        parser.feed(html)
-    except (ValueError, RuntimeError) as e:
-        logging.debug("HTML parsing issue at %s: %s", base_url, e)
-    except Exception:
-        logging.exception("Unexpected parser failure at %s", base_url)
-    return parser.links
-
-# Bounded / LRU helpers
-class LRUSet:
-    def __init__(self, maxsize: int):
-        self._data: OrderedDict = OrderedDict()
-        self._maxsize = maxsize
-
-    def __contains__(self, item) -> bool:
-        return item in self._data
-
-    def add(self, item):
-        if item in self._data:
-            self._data.move_to_end(item)
-            return
-        self._data[item] = None
-        if len(self._data) > self._maxsize:
-            self._data.popitem(last=False)
-
-    def discard(self, item):
-        self._data.pop(item, None)
-
-    def __len__(self) -> int:
-        return len(self._data)
-
-
-class BoundedDict:
-    def __init__(self, maxsize: int):
-        self._data: OrderedDict = OrderedDict()
-        self._maxsize = maxsize
-
-    def get(self, key, default=None):
-        return self._data.get(key, default)
-
-    def set(self, key, value):
-        if key in self._data:
-            self._data.move_to_end(key)
-        self._data[key] = value
-        if len(self._data) > self._maxsize:
-            self._data.popitem(last=False)
-
-    def pop(self, key, default=None):
-        return self._data.pop(key, default)
-
-    def __contains__(self, key):
-        return key in self._data
-
-
-class TTLDict:
-    def __init__(self, ttl: float, maxsize: int):
-        self._data: OrderedDict = OrderedDict()
-        self._times: dict = {}
-        self._ttl = ttl
-        self._maxsize = maxsize
-
-    def get(self, key, default=None):
-        self._maybe_evict(key)
-        return self._data.get(key, default)
-
-    def set(self, key, value):
-        now = time.monotonic()
-        self._data[key] = value
-        self._times[key] = now
-        self._data.move_to_end(key)
-        while len(self._data) > self._maxsize:
-            oldest = next(iter(self._data))
-            del self._data[oldest]
-            del self._times[oldest]
-
-    def _maybe_evict(self, key):
-        if key in self._times:
-            if time.monotonic() - self._times[key] > self._ttl:
-                del self._data[key]
-                del self._times[key]
-
-# DNS-only noise worker
-async def dns_noise_worker(
-    domains: List[str],
-    stop_event: asyncio.Event,
-    min_sleep: float = DEFAULT_DNS_MIN_SLEEP,
-    max_sleep: float = DEFAULT_DNS_MAX_SLEEP,
-    worker_id: int = 0,
-) -> None:
-    """Resolve random hostnames without making HTTP connections."""
-    rng = random.Random()
-    loop = asyncio.get_event_loop()
-    logging.info("DNS noise worker %d started (%d candidate domains)", worker_id, len(domains))
-    while not stop_event.is_set():
-        host = rng.choice(domains)
-        try:
-            await loop.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
-            logging.debug("DNS-only: resolved %s", host)
-        except socket.gaierror:
-            logging.debug("DNS-only: NXDOMAIN/timeout for %s", host)
-        except Exception as exc:
-            logging.debug("DNS-only: error for %s: %s", host, exc)
-
-        hour = time.localtime().tm_hour + time.localtime().tm_min / 60
-        weight = max(0.1, _diurnal_weight(hour))
-        scale = 1.0 / weight
-        await asyncio.sleep(rng.uniform(min_sleep, max_sleep) * scale)
-
-# Per-user crawler
-class UserCrawler:
-    def __init__(
-        self,
-        profile: UserProfile,
-        shared_root_urls: List[str],
-        shared_visited: LRUSet,
-        max_depth: int,
-        concurrency: int,
-        min_sleep: float,
-        max_sleep: float,
-        domain_delay: float,
-        total_connections: int,
-        connections_per_host: int,
-        keepalive_timeout: int,
-        max_queue_size: int,
-        max_links_per_page: int,
-        stop_event: asyncio.Event,
-    ):
-        self.profile = profile
-        self.rng = profile.rng
-        self.root_urls = set(shared_root_urls)
-        self.shared_visited = shared_visited
-        self.stop_event = stop_event
-        self.max_depth = max_depth
-        self.concurrency = concurrency
-        self.min_sleep = min_sleep
-        self.max_sleep = max_sleep
-        self.domain_delay = domain_delay
-        self.max_links_per_page = max_links_per_page
-
-        self.queue: asyncio.Queue = asyncio.Queue(maxsize=max_queue_size)
-        for url in shared_root_urls:
-            try:
-                self.queue.put_nowait((url, 0, None))
-            except asyncio.QueueFull:
-                break
-
-        self.semaphore = asyncio.Semaphore(concurrency)
-        self.domain_last_access: TTLDict = TTLDict(ttl=domain_delay * 10, maxsize=50_000)
-        self._domain_locks: weakref.WeakValueDictionary = weakref.WeakValueDictionary()
-        self._domain_locks_hard: dict = {}
-        self._domain_lock_refcounts: dict = {}
-        self.failed_counts: BoundedDict = BoundedDict(maxsize=10_000)
-        self.max_failures = 3
-        self.stats: Dict[str, int] = {"visited": 0, "failed": 0, "queued": 0}
-
-        self._connector = aiohttp.TCPConnector(
-            limit=total_connections,
-            limit_per_host=connections_per_host,
-            ttl_dns_cache=DNS_CACHE_TTL,
-            keepalive_timeout=keepalive_timeout,
-        )
-        self._session: Optional[aiohttp.ClientSession] = None
-
-    async def _get_session(self) -> aiohttp.ClientSession:
-        if self._session is None:
-            self._session = aiohttp.ClientSession(
-                connector=self._connector,
-                max_line_size=MAX_HEADER_SIZE,
-                max_field_size=MAX_HEADER_SIZE,
-            )
-        return self._session
-
-    async def close(self):
-        if self._session:
-            await self._session.close()
-            self._session = None
-        await self._connector.close()
-
-    def _get_domain_lock(self, domain: str) -> asyncio.Lock:
-        lock = self._domain_locks.get(domain)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._domain_locks[domain] = lock
-        self._domain_locks_hard[domain] = lock
-        self._domain_lock_refcounts[domain] = self._domain_lock_refcounts.get(domain, 0) + 1
-        return lock
-
-    def _release_domain_lock_ref(self, domain: str) -> None:
-        count = self._domain_lock_refcounts.get(domain, 1) - 1
-        if count <= 0:
-            self._domain_locks_hard.pop(domain, None)
-            self._domain_lock_refcounts.pop(domain, None)
-        else:
-            self._domain_lock_refcounts[domain] = count
-
-    async def wait_for_domain(self, domain: str):
-        lock = self._get_domain_lock(domain)
-        try:
-            async with lock:
-                now = time.monotonic()
-                last = self.domain_last_access.get(domain, 0)
-                delta = now - last
-                wait_time = max(0, self.domain_delay * self.rng.uniform(0.8, 1.2) - delta)
-                if wait_time > 0:
-                    await asyncio.sleep(wait_time)
-                self.domain_last_access.set(domain, time.monotonic())
-        finally:
-            self._release_domain_lock_ref(domain)
-
-    def _try_mark_visited(self, url: str) -> bool:
-        if url in self.shared_visited:
-            return False
-        self.shared_visited.add(url)
-        return True
-
-    async def fetch(
-        self,
-        url: str,
-        depth: int,
-        referrer: Optional[str],
-    ) -> Optional[List[Tuple[str, Optional[str]]]]:
-        async with self.semaphore:
-            try:
-                domain = urlsplit(url).hostname
-            except ValueError:
-                domain = None
-            if not domain:
-                return None
-
-            if not self._try_mark_visited(url):
-                return None
-
-            logging.debug("[user%d] Visiting %s (ref: %s)", self.profile.user_id, url, referrer)
-
-            session = await self._get_session()
-            try:
-                await self.wait_for_domain(domain)
-                headers = self.profile.get_headers(referrer=referrer)
-                timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
-
-                async with session.get(
-                    url,
-                    headers=headers,
-                    timeout=timeout,
-                    ssl=SSL_CONTEXT,
-                    allow_redirects=True,
-                ) as resp:
-                    if resp.status >= 400:
-                        self.stats["failed"] += 1
-                        return None
-                    raw = await resp.content.read(MAX_RESPONSE_BYTES)
-                    html = raw.decode(resp.charset or "utf-8", errors="replace")
-                    del raw
-
-                self.stats["visited"] += 1
-
-                links = extract_links(html, url)
-                del html
-                
-                logging.debug(
-                    "[user%d] %s -> extracted %d links",
-                    self.profile.user_id, url, len(links),
-                )
-
-                if links:
-                    if len(links) > self.max_links_per_page:
-                        links = self.rng.sample(links, self.max_links_per_page)
-                    else:
-                        self.rng.shuffle(links)
-                    logging.debug(
-                        "[user%d] queuing %d child links (ref=%s)",
-                        self.profile.user_id, len(links), url,
-                    )
-
-                if self.rng.random() < 0.05:
-                    for root_url in self.root_urls:
-                        self._safe_enqueue(root_url, 0, None)
-
-                pause = _activity_pause_seconds(self.rng)
-                if pause:
-                    logging.debug("[user%d] AFK pause %.0fs", self.profile.user_id, pause)
-                    await asyncio.sleep(pause)
-                else:
-                    weight = max(0.05, self.profile.diurnal_weight())
-                    scale = 1.0 / weight
-                    await asyncio.sleep(
-                        self.rng.uniform(self.min_sleep, self.max_sleep)
-                        * (1 + depth * 0.3)
-                        * self.rng.uniform(0.8, 1.5)
-                        * scale
-                    )
-
-                self.failed_counts.pop(url, None)
-                return [(link, url) for link in links] if links else []
-
-            except (aiohttp.ClientError, asyncio.TimeoutError, ssl.SSLError):
-                self.shared_visited.discard(url)
-                self.stats["failed"] += 1
-                self._record_failure(url)
-                return None
-            except Exception:
-                self.shared_visited.discard(url)
-                logging.exception("[user%d] Unexpected error fetching %s", self.profile.user_id, url)
-                self._record_failure(url)
-                return None
-
-    def _record_failure(self, url: str):
-        count = (self.failed_counts.get(url, 0) or 0) + 1
-        if count >= self.max_failures:
-            self.failed_counts.pop(url, None)
-            self.root_urls.discard(url)
-        else:
-            self.failed_counts.set(url, count)
-
-    def _safe_enqueue(self, url: str, depth: int, referrer: Optional[str]):
-        try:
-            self.queue.put_nowait((url, depth, referrer))
-            self.stats["queued"] += 1
-        except asyncio.QueueFull:
-            logging.debug("[user%d] Queue full, dropping %s", self.profile.user_id, url)
-
-    async def crawl_worker(self):
-        while not self.stop_event.is_set():
-            try:
-                url, depth, referrer = await self.queue.get()
-            except asyncio.CancelledError:
-                break
-            if depth > self.max_depth:
-                self.queue.task_done()
-                continue
-            result = await self.fetch(url, depth, referrer)
-            self.queue.task_done()
-            if result is not None and depth < self.max_depth:
-                for child_url, child_ref in result:
-                    self._safe_enqueue(child_url, depth + 1, child_ref)
-            elif result is not None and depth >= self.max_depth:
-	            logging.debug("[user%d] max_depth %d reached, not following links from %s",
-	                    self.profile.user_id, self.max_depth, url)
-
-    async def run(self):
-        workers = [asyncio.create_task(self.crawl_worker()) for _ in range(self.concurrency)]
-        await self.stop_event.wait()
-        for w in workers:
-            w.cancel()
-        await asyncio.gather(*workers, return_exceptions=True)
-        await self.close()
-
-# Shared tasks
-async def fetch_crux_top_sites(
-    session: aiohttp.ClientSession, count: int = DEFAULT_CRUX_COUNT
-) -> List[str]:
-    logging.info("Fetching CRUX top sites...")
-    async with session.get(CRUX_TOP_CSV) as resp:
-        if resp.status >= 400:
-            logging.error("CRUX fetch failed with status %s", resp.status)
-            return []
-        data = await resp.read()
-    csv_text = gzip.decompress(data).decode()
-    reader = csv.DictReader(csv_text.splitlines())
-    sites, seen = [], set()
-    for row in reader:
-        origin = row.get("origin")
-        if origin and origin not in seen:
-            seen.add(origin)
-            if not origin.startswith("http"):
-                origin = f"https://{origin}"
-            sites.append(origin)
-        if len(sites) >= count:
-            break
-    logging.info("Loaded %d CRUX sites", len(sites))
-    return sites
-
-
-def setup_logging(log_level_str: str, logfile: Optional[str] = None):
-    level = getattr(logging, log_level_str.upper(), logging.INFO)
+from noisy_lib.config import DEFAULT_URL_BLACKLIST, DEFAULT_VISITED_MAX, SECONDS_PER_DAY
+from noisy_lib.config_loader import build_parser, load_config_file, validate_args
+from noisy_lib.crawler import SharedMetrics, UserCrawler
+from noisy_lib.fetchers import fetch_crux_top_sites, fetch_user_agents
+from noisy_lib.profiles import UAPool, UserProfile, _UA_FALLBACK
+from noisy_lib.rate_limiter import DomainRateLimiter
+from noisy_lib.structures import LRUSet
+from noisy_lib.workers import dns_noise_worker, http_noise_worker, refresh_user_agents_loop, stats_reporter
+
+log = logging.getLogger(__name__)
+
+
+def setup_logging(level_str: str, logfile: Optional[str] = None):
+    level = getattr(logging, level_str.upper(), logging.INFO)
     root = logging.getLogger()
     root.handlers.clear()
     root.setLevel(level)
-    formatter = logging.Formatter("%(levelname)s - %(message)s")
+    fmt = logging.Formatter("%(levelname)s - %(message)s")
     sh = logging.StreamHandler()
-    sh.setFormatter(formatter)
+    sh.setFormatter(fmt)
     root.addHandler(sh)
     if logfile:
         fh = logging.FileHandler(logfile)
         fh.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
         root.addHandler(fh)
-    logging.getLogger("aiohttp").setLevel(
-        logging.DEBUG if level == logging.DEBUG else logging.ERROR
-    )
+    logging.getLogger("aiohttp").setLevel(logging.DEBUG if level == logging.DEBUG else logging.ERROR)
 
 
-async def stats_reporter(crawlers: List[UserCrawler], stop_event: asyncio.Event):
-    while not stop_event.is_set():
-        await asyncio.sleep(60)
-        total_v = sum(c.stats["visited"] for c in crawlers)
-        total_f = sum(c.stats["failed"] for c in crawlers)
-        total_q = sum(c.stats["queued"] for c in crawlers)
-        per_user = " | ".join(f"u{c.profile.user_id}:{c.stats['visited']}v" for c in crawlers)
-        logging.info("Stats | visited=%d failed=%d queued=%d | %s", total_v, total_f, total_q, per_user)
-
-
-async def refresh_user_agents_loop(
-    stop_event: asyncio.Event,
-    ua_refresh_seconds: int,
-    crawlers: List[UserCrawler],
-):
-    await asyncio.sleep(ua_refresh_seconds)
-    async with aiohttp.ClientSession() as session:
-        while not stop_event.is_set():
-            agents = await fetch_user_agents(session)
-            if agents:
-                await ua_pool.replace(agents)
-                sampled = ua_pool.sample(len(crawlers))
-                for crawler, ua in zip(crawlers, sampled):
-                    crawler.profile.ua = ua
-                logging.info("UA pool refreshed (%d agents)", len(agents))
-            await asyncio.sleep(ua_refresh_seconds)
-
-# Entry point
 async def main_async(args):
     setup_logging(args.log, args.logfile)
 
+    errors = validate_args(args)
+    if errors:
+        for e in errors:
+            log.error(f"[CONFIG] {e}")
+        sys.exit(1)
+
+    if args.dry_run:
+        pq = max(10, args.max_queue_size // args.num_users)
+        log.info(f"[DRY-RUN] threads={args.threads} users={args.num_users} depth={args.max_depth} | sleep=[{args.min_sleep},{args.max_sleep}]s delay={args.domain_delay}s")
+        log.info(f"[DRY-RUN] crux={args.crux_count} dns_workers={args.dns_workers} timeout={args.timeout} | per_user_queue={pq} max_links={args.max_links_per_page}")
+        return
+
+    ua_pool = UAPool(_UA_FALLBACK)
     async with aiohttp.ClientSession() as session:
         top_sites = await fetch_crux_top_sites(session, count=args.crux_count)
         initial_uas = await fetch_user_agents(session)
@@ -678,109 +62,96 @@ async def main_async(args):
             await ua_pool.replace(initial_uas)
 
     if not top_sites:
-        logging.error("No seed sites loaded; exiting.")
+        log.error("[FATAL] Aucun site CRUX chargé — arrêt.")
         return
 
-    crux_refresh_seconds = int(args.crux_refresh_days * SECONDS_PER_DAY)
-    ua_refresh_seconds = int(args.ua_refresh_days * SECONDS_PER_DAY)
-
     stop_event = asyncio.Event()
-    shared_visited: LRUSet = LRUSet(maxsize=DEFAULT_VISITED_MAX)
+    shared_visited = LRUSet(maxsize=DEFAULT_VISITED_MAX)
+    rate_limiter = DomainRateLimiter(domain_delay=args.domain_delay)
+    shared_metrics = SharedMetrics()
 
-    num_users = args.num_users
-    ua_list = ua_pool.sample(num_users)
-    profiles = [
-        UserProfile(user_id=i, ua=ua_list[i], rng=random.Random(_RANDOM.random()))
-        for i in range(num_users)
-    ]
+    _rng = random.Random()
+    ua_list = ua_pool.sample(args.num_users, rng=_rng)
+    per_user_queue = max(10, args.max_queue_size // args.num_users)
 
     crawlers: List[UserCrawler] = []
-    for profile in profiles:
-        user_sites = list(top_sites)
-        profile.rng.shuffle(user_sites)
-        crawler = UserCrawler(
-            profile=profile,
-            shared_root_urls=user_sites[:500],
-            shared_visited=shared_visited,
-
-            max_depth=args.max_depth,
-            concurrency=args.threads,
-            min_sleep=args.min_sleep,
-            max_sleep=args.max_sleep,
-            domain_delay=args.domain_delay,
+    for i in range(args.num_users):
+        profile = UserProfile(user_id=i, ua=ua_list[i], rng=random.Random(_rng.random()))
+        sites = list(top_sites)
+        profile.rng.shuffle(sites)
+        crawlers.append(UserCrawler(
+            profile=profile, shared_root_urls=sites[:500],
+            shared_visited=shared_visited, rate_limiter=rate_limiter,
+            max_depth=args.max_depth, concurrency=args.threads,
+            min_sleep=args.min_sleep, max_sleep=args.max_sleep,
+            max_queue_size=per_user_queue, max_links_per_page=args.max_links_per_page,
+            url_blacklist=DEFAULT_URL_BLACKLIST, stop_event=stop_event,
             total_connections=args.total_connections,
             connections_per_host=args.connections_per_host,
             keepalive_timeout=args.keepalive_timeout,
-            max_queue_size=args.max_queue_size // num_users,
-            max_links_per_page=args.max_links_per_page,
-            stop_event=stop_event,
+            shared_metrics=shared_metrics,
+        ))
+
+    dns_hosts = [h for h in (urlsplit(s).hostname for s in top_sites) if h]
+    ua_refresh_s = int(args.ua_refresh_days * SECONDS_PER_DAY)
+
+    tasks = (
+        [asyncio.create_task(c.run()) for c in crawlers]
+        + [asyncio.create_task(dns_noise_worker(dns_hosts, stop_event, worker_id=i)) for i in range(args.dns_workers)]
+        + [asyncio.create_task(stats_reporter(crawlers, stop_event)),
+           asyncio.create_task(refresh_user_agents_loop(stop_event, ua_refresh_s, crawlers, ua_pool))]
+        + [asyncio.create_task(http_noise_worker(dns_hosts, stop_event, worker_id=i))
+           for i in range(args.post_noise_workers)]
+    )
+
+    if args.dashboard:
+        from noisy_lib.dashboard import MetricsCollector, start_dashboard
+        collector = MetricsCollector(
+            crawlers, shared_visited, rate_limiter, ua_pool,
+            shared_metrics, webhook_url=args.webhook_url,
         )
-        crawlers.append(crawler)
-
-    dns_hosts: List[str] = [
-        h for h in (urlsplit(s).hostname for s in top_sites) if h
-    ]
-
-    tasks = []
-    for crawler in crawlers:
-        tasks.append(asyncio.create_task(crawler.run()))
-    for i in range(args.dns_workers):
-        tasks.append(asyncio.create_task(dns_noise_worker(dns_hosts, stop_event, worker_id=i)))
-    tasks.append(asyncio.create_task(stats_reporter(crawlers, stop_event)))
-    tasks.append(asyncio.create_task(refresh_user_agents_loop(stop_event, ua_refresh_seconds, crawlers)))
+        tasks.append(asyncio.create_task(start_dashboard(collector, args.dashboard_port, args.dashboard_host)))
 
     if args.timeout:
         async def _stopper():
-            logging.info("Will stop after %d seconds", args.timeout)
             await asyncio.sleep(args.timeout)
-            logging.info("Timeout reached — stopping")
             stop_event.set()
         tasks.append(asyncio.create_task(_stopper()))
-
     await stop_event.wait()
     for t in tasks:
         t.cancel()
     await asyncio.gather(*tasks, return_exceptions=True)
-
-	# Explicitly close each crawler's session and connector
-    close_tasks = [asyncio.create_task(c.close()) for c in crawlers]
-    await asyncio.gather(*close_tasks, return_exceptions=True)
-
-    logging.info("All tasks shut down cleanly.")
+    await asyncio.gather(*[asyncio.create_task(c.close()) for c in crawlers], return_exceptions=True)
+    log.info("[FIN] main_async | arrêt propre")
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="DNS/HTTP noise generator"
-    )
-    parser.add_argument("--log", default="info", choices=["debug", "info", "warning", "error"])
-    parser.add_argument("--logfile")
-    parser.add_argument("--threads", type=int, default=DEFAULT_THREADS,
-                        help="Concurrent workers per virtual user (default: %(default)s)")
-    parser.add_argument("--num_users", type=int, default=DEFAULT_NUM_USERS,
-                        help="Number of virtual users to simulate (default: %(default)s)")
-    parser.add_argument("--max_depth", type=int, default=DEFAULT_MAX_DEPTH)
-    parser.add_argument("--min_sleep", type=float, default=DEFAULT_MIN_SLEEP)
-    parser.add_argument("--max_sleep", type=float, default=DEFAULT_MAX_SLEEP)
-    parser.add_argument("--domain_delay", type=float, default=DEFAULT_DOMAIN_DELAY)
-    parser.add_argument("--total_connections", type=int, default=DEFAULT_TOTAL_CONNECTIONS,
-                        help="Max TCP connections per virtual user (default: %(default)s)")
-    parser.add_argument("--connections_per_host", type=int, default=DEFAULT_CONNECTIONS_PER_HOST)
-    parser.add_argument("--keepalive_timeout", type=int, default=DEFAULT_KEEPALIVE_TIMEOUT)
-    parser.add_argument("--crux_count", type=int, default=DEFAULT_CRUX_COUNT)
-    parser.add_argument("--crux_refresh_days", type=float, default=DEFAULT_CRUX_REFRESH_DAYS)
-    parser.add_argument("--ua_refresh_days", type=float, default=DEFAULT_UA_REFRESH_DAYS)
-    parser.add_argument("--max_queue_size", type=int, default=DEFAULT_MAX_QUEUE_SIZE)
-    parser.add_argument("--max_links_per_page", type=int, default=DEFAULT_MAX_LINKS_PER_PAGE)
-    parser.add_argument("--dns_workers", type=int, default=DEFAULT_DNS_WORKERS,
-                        help="Background DNS-only noise workers (default: %(default)s)")
-    parser.add_argument("--timeout", type=int, default=DEFAULT_RUN_TIMEOUT_SECONDS,
-                        help="Stop after N seconds. Default: run forever")
+    pre = __import__("argparse").ArgumentParser(add_help=False)
+    pre.add_argument("--config")
+    pre_args, _ = pre.parse_known_args()
+
+    parser = build_parser()
+    if pre_args.config:
+        overrides = load_config_file(pre_args.config)
+        if overrides:
+            parser.set_defaults(**overrides)
+
     args = parser.parse_args()
+
+    if args.validate_config:
+        setup_logging(args.log)
+        errors = validate_args(args)
+        if errors:
+            for e in errors:
+                logging.error(f"[CONFIG] {e}")
+            sys.exit(1)
+        logging.info("[CONFIG] valide")
+        sys.exit(0)
+
     try:
         asyncio.run(main_async(args))
     except KeyboardInterrupt:
-        logging.info("Interrupted — exiting cleanly")
+        logging.info("[STOP] interruption clavier")
 
 
 if __name__ == "__main__":

--- a/noisy_lib/__init__.py
+++ b/noisy_lib/__init__.py
@@ -1,0 +1,1 @@
+# noisy_lib - modular internals for the noisy crawler

--- a/noisy_lib/config.py
+++ b/noisy_lib/config.py
@@ -1,0 +1,68 @@
+# config.py - Toutes constantes du projet
+# IN: rien | OUT: constantes importées | MODIFIE: rien
+# APPELÉ PAR: tous modules | APPELLE: rien
+
+# ---- CRUX ----
+CRUX_TOP_CSV = "https://raw.githubusercontent.com/zakird/crux-top-lists/main/data/global/current.csv.gz"
+DEFAULT_CRUX_COUNT = 10_000
+DEFAULT_CRUX_REFRESH_DAYS = 31
+
+# ---- USER AGENT POOL ----
+UA_PAGE_URL = "https://www.useragents.me"
+DEFAULT_UA_COUNT = 50
+DEFAULT_UA_REFRESH_DAYS = 7
+
+# ---- CRAWLER ----
+DEFAULT_MAX_QUEUE_SIZE = 100_000
+DEFAULT_MAX_DEPTH = 5
+DEFAULT_THREADS = 10
+DEFAULT_NUM_USERS = 5
+DEFAULT_MAX_LINKS_PER_PAGE = 50
+
+# ---- TIMING ----
+DEFAULT_MIN_SLEEP = 2
+DEFAULT_MAX_SLEEP = 15
+DEFAULT_DOMAIN_DELAY = 5.0
+DEFAULT_DNS_MIN_SLEEP = 5
+DEFAULT_DNS_MAX_SLEEP = 30
+
+# ---- CONNEXIONS (par user) ----
+DEFAULT_TOTAL_CONNECTIONS = 40
+DEFAULT_CONNECTIONS_PER_HOST = 4
+DEFAULT_KEEPALIVE_TIMEOUT = 30
+DNS_CACHE_TTL = 120
+
+# ---- RÉSEAU ----
+REQUEST_TIMEOUT = 15
+MAX_RESPONSE_BYTES = 512 * 1024
+MAX_HEADER_SIZE = 32 * 1024
+
+# ---- RUNTIME ----
+DEFAULT_RUN_TIMEOUT_SECONDS = None
+SECONDS_PER_DAY = 24 * 60 * 60
+DEFAULT_DNS_WORKERS = 3
+
+# ---- CACHE ----
+DEFAULT_VISITED_MAX = 500_000
+
+# ---- RETRY ----
+MAX_RETRIES = 3
+RETRY_BASE_DELAY = 1.0
+
+# ---- DASHBOARD ----
+DEFAULT_DASHBOARD_PORT = 8080
+DASHBOARD_UPDATE_INTERVAL = 2
+DEFAULT_POST_NOISE_WORKERS = 1
+ALERT_FAIL_THRESHOLD = 30.0  # % failure rate to trigger alert
+WEBHOOK_TIMEOUT = 10
+
+# ---- URL BLACKLIST ----
+DEFAULT_URL_BLACKLIST = [
+    "t.co", "t.umblr.com", "messenger.com", "itunes.apple.com",
+    "l.facebook.com", "bit.ly", "mediawiki",
+    ".css", ".ico", ".xml", ".json", ".png", ".iso", ".pdf", ".zip", ".exe", ".dmg",
+    "intent/tweet", "twitter.com/share", "dialog/feed?",
+    "zendesk", "clickserve",
+    "logout", "signout", "sign-out", "log-out",
+    "javascript:", "mailto:", "tel:",
+]

--- a/noisy_lib/config_loader.py
+++ b/noisy_lib/config_loader.py
@@ -1,0 +1,107 @@
+# config_loader.py - Parsing CLI, validation, chargement config fichier
+# IN: sys.argv, fichier JSON | OUT: argparse.Namespace | MODIFIE: rien
+# APPELÉ PAR: noisy.py | APPELLE: config, argparse, json
+
+import argparse
+import json
+import logging
+from typing import List
+
+from .config import (
+    DEFAULT_CONNECTIONS_PER_HOST, DEFAULT_CRUX_COUNT, DEFAULT_CRUX_REFRESH_DAYS,
+    DEFAULT_DASHBOARD_PORT, DEFAULT_DNS_WORKERS, DEFAULT_DOMAIN_DELAY,
+    DEFAULT_KEEPALIVE_TIMEOUT, DEFAULT_MAX_DEPTH, DEFAULT_MAX_LINKS_PER_PAGE,
+    DEFAULT_MAX_QUEUE_SIZE, DEFAULT_MAX_SLEEP, DEFAULT_MIN_SLEEP,
+    DEFAULT_NUM_USERS, DEFAULT_POST_NOISE_WORKERS, DEFAULT_RUN_TIMEOUT_SECONDS,
+    DEFAULT_THREADS, DEFAULT_TOTAL_CONNECTIONS, DEFAULT_UA_REFRESH_DAYS,
+)
+
+log = logging.getLogger(__name__)
+
+
+def load_config_file(path: str) -> dict:
+    """Charge un fichier JSON et retourne les overrides CLI compatibles."""
+    log.info(f"[DEBUT] load_config_file | path={path}")
+    try:
+        with open(path) as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        log.warning(f"[WARN] load_config_file | {e}")
+        return {}
+
+    supported = {
+        "max_depth", "min_sleep", "max_sleep", "timeout",
+        "threads", "num_users", "domain_delay", "max_queue_size",
+        "max_links_per_page", "crux_count", "dns_workers",
+    }
+    result = {k: v for k, v in data.items() if k in supported and v not in (None, False)}
+    log.info(f"[FIN] load_config_file | keys={list(result.keys())}")
+    return result
+
+
+def validate_args(args) -> List[str]:
+    """Valide les arguments. Retourne liste d'erreurs (vide = OK)."""
+    errors = []
+    if args.min_sleep > args.max_sleep:
+        errors.append(f"--min_sleep ({args.min_sleep}) doit être <= --max_sleep ({args.max_sleep})")
+    if args.threads <= 0:
+        errors.append(f"--threads doit être > 0, reçu {args.threads}")
+    if args.num_users <= 0:
+        errors.append(f"--num_users doit être > 0, reçu {args.num_users}")
+    if args.max_depth <= 0:
+        errors.append(f"--max_depth doit être > 0, reçu {args.max_depth}")
+    if args.crux_count <= 0:
+        errors.append(f"--crux_count doit être > 0, reçu {args.crux_count}")
+    if args.domain_delay < 0:
+        errors.append(f"--domain_delay doit être >= 0, reçu {args.domain_delay}")
+    if args.connections_per_host <= 0:
+        errors.append("--connections_per_host doit être > 0")
+    if args.total_connections < args.connections_per_host:
+        errors.append(
+            f"--total_connections ({args.total_connections}) doit être >= "
+            f"--connections_per_host ({args.connections_per_host})"
+        )
+    per_user_queue = args.max_queue_size // args.num_users if args.num_users > 0 else 0
+    if per_user_queue < 10:
+        errors.append(f"Queue par user trop petite ({per_user_queue}). Augmenter --max_queue_size.")
+    return errors
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Construit le parser CLI complet."""
+    p = argparse.ArgumentParser(description="Générateur de bruit DNS/HTTP")
+    p.add_argument("--config", help="Fichier JSON de configuration (les flags CLI ont priorité)")
+    p.add_argument("--validate-config", action="store_true", help="Valide la config et quitte")
+    p.add_argument("--dry-run", action="store_true", help="Affiche la config résolue sans crawler")
+    p.add_argument("--log", default="info", choices=["debug", "info", "warning", "error"])
+    p.add_argument("--logfile")
+    p.add_argument("--threads", type=int, default=DEFAULT_THREADS,
+                   help="Workers parallèles par user (défaut: %(default)s)")
+    p.add_argument("--num_users", type=int, default=DEFAULT_NUM_USERS,
+                   help="Nombre d'utilisateurs virtuels (défaut: %(default)s)")
+    p.add_argument("--max_depth", type=int, default=DEFAULT_MAX_DEPTH)
+    p.add_argument("--min_sleep", type=float, default=DEFAULT_MIN_SLEEP)
+    p.add_argument("--max_sleep", type=float, default=DEFAULT_MAX_SLEEP)
+    p.add_argument("--domain_delay", type=float, default=DEFAULT_DOMAIN_DELAY)
+    p.add_argument("--total_connections", type=int, default=DEFAULT_TOTAL_CONNECTIONS)
+    p.add_argument("--connections_per_host", type=int, default=DEFAULT_CONNECTIONS_PER_HOST)
+    p.add_argument("--keepalive_timeout", type=int, default=DEFAULT_KEEPALIVE_TIMEOUT)
+    p.add_argument("--crux_count", type=int, default=DEFAULT_CRUX_COUNT)
+    p.add_argument("--crux_refresh_days", type=float, default=DEFAULT_CRUX_REFRESH_DAYS)
+    p.add_argument("--ua_refresh_days", type=float, default=DEFAULT_UA_REFRESH_DAYS)
+    p.add_argument("--max_queue_size", type=int, default=DEFAULT_MAX_QUEUE_SIZE)
+    p.add_argument("--max_links_per_page", type=int, default=DEFAULT_MAX_LINKS_PER_PAGE)
+    p.add_argument("--dns_workers", type=int, default=DEFAULT_DNS_WORKERS)
+    p.add_argument("--timeout", type=int, default=DEFAULT_RUN_TIMEOUT_SECONDS,
+                   help="Arrêt après N secondes (défaut: infini)")
+    p.add_argument("--dashboard", action="store_true",
+                   help="Active le dashboard web temps réel")
+    p.add_argument("--dashboard-port", type=int, default=DEFAULT_DASHBOARD_PORT,
+                   help="Port du dashboard (défaut: %(default)s)")
+    p.add_argument("--dashboard-host", default="127.0.0.1",
+                   help="Adresse du dashboard (défaut: 127.0.0.1)")
+    p.add_argument("--post-noise-workers", type=int, default=DEFAULT_POST_NOISE_WORKERS,
+                   help="Workers POST bruit (défaut: %(default)s)")
+    p.add_argument("--webhook-url", default=None,
+                   help="URL webhook pour alertes (optionnel)")
+    return p

--- a/noisy_lib/constants.py
+++ b/noisy_lib/constants.py
@@ -1,0 +1,2 @@
+# constants.py - COMPATIBILITÉ : importer depuis noisy_lib.config
+from noisy_lib.config import *  # noqa: F401, F403

--- a/noisy_lib/crawler.py
+++ b/noisy_lib/crawler.py
@@ -1,0 +1,317 @@
+# crawler.py - Orchestration crawl par utilisateur virtuel
+# IN: UserProfile, shared state | OUT: none | MODIFIE: LRUSet visited, stats dict
+# APPELÉ PAR: noisy.py | APPELLE: rate_limiter, fetch_client, extractor, profiles
+
+import asyncio
+import collections
+import logging
+import ssl
+import time
+from typing import Dict, List, Optional
+from urllib.parse import urlsplit
+
+import aiohttp
+
+from .config import DNS_CACHE_TTL, MAX_HEADER_SIZE
+from .extractor import extract_links
+from .fetch_client import fetch_with_retry
+from .profiles import UserProfile, _activity_pause_seconds
+from .rate_limiter import DomainRateLimiter
+from .structures import BoundedDict, LRUSet
+
+log = logging.getLogger(__name__)
+
+# Shared structures for cross-crawler metrics
+RequestLogEntry = collections.namedtuple("RequestLogEntry", ["ts", "user_id", "url", "domain", "status", "bytes", "error"])
+
+
+class SharedMetrics:
+    """Métriques partagées entre tous les crawlers (accès thread-safe via asyncio)."""
+
+    def __init__(self, max_log: int = 200):
+        self.request_log: collections.deque = collections.deque(maxlen=max_log)
+        self.domain_stats: Dict[str, Dict[str, int]] = {}  # domain -> {ok, fail, bytes}
+        self.tld_counts: Dict[str, int] = {}
+        self.total_bytes: int = 0
+        self.recent_errors: collections.deque = collections.deque(maxlen=50)
+        self.pause_event: asyncio.Event = asyncio.Event()
+        self.pause_event.set()  # not paused by default
+        self._start_time: float = time.monotonic()
+
+    def log_request(self, user_id: int, url: str, domain: str, status: int, nbytes: int, error: str):
+        self.request_log.append(RequestLogEntry(
+            ts=time.time(), user_id=user_id, url=url, domain=domain,
+            status=status, bytes=nbytes, error=error,
+        ))
+        # Domain stats
+        if domain not in self.domain_stats:
+            self.domain_stats[domain] = {"ok": 0, "fail": 0, "bytes": 0}
+        ds = self.domain_stats[domain]
+        if 200 <= status < 400:
+            ds["ok"] += 1
+        else:
+            ds["fail"] += 1
+        ds["bytes"] += nbytes
+        # TLD
+        tld = domain.rsplit(".", 1)[-1] if domain and "." in domain else "local"
+        self.tld_counts[tld] = self.tld_counts.get(tld, 0) + 1
+        # Bandwidth
+        self.total_bytes += nbytes
+        # Errors
+        if error:
+            self.recent_errors.append({
+                "ts": time.time(), "user_id": user_id,
+                "url": url[:120], "domain": domain,
+                "status": status, "error": error,
+            })
+
+    def domain_health(self, domain: str) -> float:
+        """Score 0.0 (bad) to 1.0 (good) based on success rate. Minimum 10 samples."""
+        ds = self.domain_stats.get(domain)
+        if not ds:
+            return 1.0
+        total = ds["ok"] + ds["fail"]
+        if total < 10:
+            return 1.0
+        return ds["ok"] / total
+
+    def top_domains(self, n: int = 20) -> List[dict]:
+        """Top N domains by total requests."""
+        items = sorted(self.domain_stats.items(), key=lambda x: x[1]["ok"] + x[1]["fail"], reverse=True)
+        result = []
+        for domain, ds in items[:n]:
+            total = ds["ok"] + ds["fail"]
+            result.append({
+                "domain": domain,
+                "ok": ds["ok"],
+                "fail": ds["fail"],
+                "total": total,
+                "health": round(ds["ok"] / total, 2) if total > 0 else 1.0,
+                "bytes": ds["bytes"],
+            })
+        return result
+
+    def tld_distribution(self) -> List[dict]:
+        """TLD distribution sorted by count."""
+        items = sorted(self.tld_counts.items(), key=lambda x: x[1], reverse=True)
+        return [{"tld": f".{tld}", "count": c} for tld, c in items[:15]]
+
+    def fingerprint_score(self) -> dict:
+        """Analyse traffic pattern for naturalness. Higher = more natural."""
+        scores = {}
+        # Domain diversity: how many unique domains vs total requests
+        total_reqs = sum(d["ok"] + d["fail"] for d in self.domain_stats.values())
+        n_domains = len(self.domain_stats)
+        scores["domain_diversity"] = min(1.0, n_domains / 100) if n_domains > 0 else 0
+        # TLD diversity: how many unique TLDs
+        n_tlds = len(self.tld_counts)
+        scores["tld_diversity"] = min(1.0, n_tlds / 20)
+        # Timing regularity: check if request intervals are too uniform
+        if len(self.request_log) >= 10:
+            intervals = []
+            logs = list(self.request_log)
+            for i in range(1, min(50, len(logs))):
+                intervals.append(logs[i].ts - logs[i - 1].ts)
+            if intervals:
+                mean_i = sum(intervals) / len(intervals)
+                variance = sum((x - mean_i) ** 2 for x in intervals) / len(intervals)
+                cv = (variance ** 0.5) / mean_i if mean_i > 0 else 0
+                scores["timing_variance"] = min(1.0, cv / 1.5)
+            else:
+                scores["timing_variance"] = 0
+        else:
+            scores["timing_variance"] = 0
+        # Overall
+        weights = {"domain_diversity": 0.4, "tld_diversity": 0.3, "timing_variance": 0.3}
+        overall = sum(scores[k] * weights[k] for k in weights)
+        return {
+            "overall": round(overall, 2),
+            "domain_diversity": round(scores["domain_diversity"], 2),
+            "tld_diversity": round(scores["tld_diversity"], 2),
+            "timing_variance": round(scores["timing_variance"], 2),
+        }
+
+    @property
+    def is_paused(self) -> bool:
+        return not self.pause_event.is_set()
+
+    def pause(self):
+        self.pause_event.clear()
+
+    def resume(self):
+        self.pause_event.set()
+
+
+class UserCrawler:
+    def __init__(
+        self, profile: UserProfile, shared_root_urls: List[str],
+        shared_visited: LRUSet, rate_limiter: DomainRateLimiter,
+        max_depth: int, concurrency: int, min_sleep: float, max_sleep: float,
+        max_queue_size: int, max_links_per_page: int, url_blacklist: List[str],
+        stop_event: asyncio.Event, total_connections: int,
+        connections_per_host: int, keepalive_timeout: int,
+        shared_metrics: Optional["SharedMetrics"] = None,
+    ):
+        self.profile = profile
+        self.rng = profile.rng
+        self.root_urls = set(shared_root_urls)
+        self.shared_visited = shared_visited
+        self.rate_limiter = rate_limiter
+        self.stop_event = stop_event
+        self.max_depth = max_depth
+        self.concurrency = concurrency
+        self.min_sleep = min_sleep
+        self.max_sleep = max_sleep
+        self.max_links_per_page = max_links_per_page
+        self.url_blacklist = url_blacklist
+        self.failed_counts: BoundedDict = BoundedDict(maxsize=10_000)
+        self.max_failures = 3
+        self.stats: Dict[str, int] = {
+            "visited": 0, "failed": 0, "client_errors": 0,
+            "server_errors": 0, "network_errors": 0, "queued": 0,
+            "bytes": 0,
+        }
+        self.queue: asyncio.Queue = asyncio.Queue(maxsize=max_queue_size)
+        for url in shared_root_urls:
+            try:
+                self.queue.put_nowait((url, 0, None))
+            except asyncio.QueueFull:
+                break
+        self.semaphore = asyncio.Semaphore(concurrency)
+        self._connector = aiohttp.TCPConnector(
+            limit=total_connections, limit_per_host=connections_per_host,
+            ttl_dns_cache=DNS_CACHE_TTL, keepalive_timeout=keepalive_timeout,
+        )
+        self._session: Optional[aiohttp.ClientSession] = None
+        self.shared_metrics = shared_metrics
+
+    async def _session_get(self) -> aiohttp.ClientSession:
+        if self._session is None:
+            self._session = aiohttp.ClientSession(
+                connector=self._connector,
+                max_line_size=MAX_HEADER_SIZE, max_field_size=MAX_HEADER_SIZE,
+            )
+        return self._session
+
+    async def close(self):
+        if self._session:
+            await self._session.close()
+            self._session = None
+        await self._connector.close()
+
+    async def fetch(self, url: str, depth: int, referrer: Optional[str]) -> Optional[List]:
+        async with self.semaphore:
+            domain = urlsplit(url).hostname
+            if not domain or any(b in url for b in self.url_blacklist):
+                return None
+            if url in self.shared_visited:
+                return None
+            # Pause support
+            if self.shared_metrics and self.shared_metrics.is_paused:
+                await self.shared_metrics.pause_event.wait()
+            # Domain health: skip domains with < 20% success rate
+            if self.shared_metrics and self.shared_metrics.domain_health(domain) < 0.2:
+                return None
+            self.shared_visited.add(url)
+            log.debug(f"[FETCH] u={self.profile.user_id} depth={depth} url={url}")
+            session = await self._session_get()
+            try:
+                await self.rate_limiter.wait(domain, self.rng)
+                result = await fetch_with_retry(session, url, self.profile.get_headers(referrer))
+                if not result.ok:
+                    self.stats["failed"] += 1
+                    if result.is_client_error:
+                        self.stats["client_errors"] += 1
+                    elif result.is_server_error:
+                        self.stats["server_errors"] += 1
+                        self.shared_visited.discard(url)
+                    if self.shared_metrics:
+                        self.shared_metrics.log_request(
+                            self.profile.user_id, url, domain,
+                            result.status, 0, result.error_msg,
+                        )
+                    return None
+                html = result.html
+                self.stats["visited"] += 1
+                self.stats["bytes"] += result.bytes_received
+                if self.shared_metrics:
+                    self.shared_metrics.log_request(
+                        self.profile.user_id, url, domain,
+                        result.status, result.bytes_received, "",
+                    )
+                links = extract_links(html, url, blacklist=self.url_blacklist)
+                del html
+                if links:
+                    links = self.rng.sample(links, min(len(links), self.max_links_per_page))
+                if self.rng.random() < 0.05:
+                    for root in self.root_urls:
+                        self._enqueue(root, 0, None)
+                pause = _activity_pause_seconds(self.rng)
+                if pause:
+                    await asyncio.sleep(pause)
+                else:
+                    weight = max(0.05, self.profile.diurnal_weight())
+                    await asyncio.sleep(
+                        self.rng.uniform(self.min_sleep, self.max_sleep)
+                        * (1 + depth * 0.3) * self.rng.uniform(0.8, 1.5) / weight
+                    )
+                self.failed_counts.pop(url, None)
+                return [(lnk, url) for lnk in links] if links else []
+            except (aiohttp.ClientError, asyncio.TimeoutError, ssl.SSLError) as e:
+                self.shared_visited.discard(url)
+                self.stats["failed"] += 1
+                self.stats["network_errors"] += 1
+                self._record_failure(url)
+                if self.shared_metrics:
+                    self.shared_metrics.log_request(
+                        self.profile.user_id, url, domain, 0, 0, str(e)[:100],
+                    )
+                return None
+            except Exception as e:
+                self.shared_visited.discard(url)
+                self.stats["failed"] += 1
+                self.stats["network_errors"] += 1
+                log.error(f"[ERREUR] fetch | u={self.profile.user_id} url={url} {e}")
+                self._record_failure(url)
+                if self.shared_metrics:
+                    self.shared_metrics.log_request(
+                        self.profile.user_id, url, domain, 0, 0, str(e)[:100],
+                    )
+                return None
+
+    def _record_failure(self, url: str):
+        count = (self.failed_counts.get(url, 0) or 0) + 1
+        if count >= self.max_failures:
+            self.failed_counts.pop(url, None)
+            self.root_urls.discard(url)
+        else:
+            self.failed_counts.set(url, count)
+
+    def _enqueue(self, url: str, depth: int, referrer: Optional[str]):
+        try:
+            self.queue.put_nowait((url, depth, referrer))
+            self.stats["queued"] += 1
+        except asyncio.QueueFull:
+            pass
+
+    async def crawl_worker(self):
+        while not self.stop_event.is_set():
+            try:
+                url, depth, referrer = await self.queue.get()
+            except asyncio.CancelledError:
+                break
+            skip = depth > self.max_depth
+            result = None if skip else await self.fetch(url, depth, referrer)
+            self.queue.task_done()
+            if result is not None and depth < self.max_depth:
+                for child_url, child_ref in result:
+                    self._enqueue(child_url, depth + 1, child_ref)
+
+    async def run(self):
+        log.info(f"[DEBUT] crawler | u={self.profile.user_id}")
+        workers = [asyncio.create_task(self.crawl_worker()) for _ in range(self.concurrency)]
+        await self.stop_event.wait()
+        for w in workers: w.cancel()
+        await asyncio.gather(*workers, return_exceptions=True)
+        await self.close()
+        log.info(f"[FIN] crawler | u={self.profile.user_id} visited={self.stats['visited']}")

--- a/noisy_lib/dashboard.py
+++ b/noisy_lib/dashboard.py
@@ -1,0 +1,304 @@
+# dashboard.py - Serveur dashboard temps réel (FastAPI + WebSocket)
+# IN: crawlers, shared_visited, rate_limiter, ua_pool, shared_metrics | OUT: app FastAPI | MODIFIE: rien
+# APPELÉ PAR: noisy.py | APPELLE: config, fastapi, uvicorn
+
+import asyncio
+import json
+import logging
+import math
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import List, Optional, TYPE_CHECKING
+
+from fastapi import FastAPI, WebSocket, WebSocketDisconnect
+from fastapi.responses import HTMLResponse, PlainTextResponse, JSONResponse
+
+from .config import ALERT_FAIL_THRESHOLD, DASHBOARD_UPDATE_INTERVAL, WEBHOOK_TIMEOUT
+from .profiles import _diurnal_weight
+
+if TYPE_CHECKING:
+    from .crawler import SharedMetrics, UserCrawler
+    from .profiles import UAPool
+    from .rate_limiter import DomainRateLimiter
+    from .structures import LRUSet
+
+log = logging.getLogger(__name__)
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+
+class MetricsCollector:
+    """Collecte les métriques depuis les crawlers et l'état partagé."""
+
+    def __init__(
+        self,
+        crawlers: List["UserCrawler"],
+        shared_visited: "LRUSet",
+        rate_limiter: "DomainRateLimiter",
+        ua_pool: "UAPool",
+        shared_metrics: "SharedMetrics",
+        webhook_url: Optional[str] = None,
+    ):
+        self.crawlers = crawlers
+        self.shared_visited = shared_visited
+        self.rate_limiter = rate_limiter
+        self.ua_pool = ua_pool
+        self.shared_metrics = shared_metrics
+        self.webhook_url = webhook_url
+        self._start_time = time.monotonic()
+        self._prev_visited = 0
+        self._prev_time = time.monotonic()
+        self._alert_fired = False
+
+    def collect(self) -> dict:
+        now = time.monotonic()
+        total_v = sum(c.stats["visited"] for c in self.crawlers)
+        total_f = sum(c.stats["failed"] for c in self.crawlers)
+        total_q = sum(c.stats["queued"] for c in self.crawlers)
+        total_4xx = sum(c.stats["client_errors"] for c in self.crawlers)
+        total_5xx = sum(c.stats["server_errors"] for c in self.crawlers)
+        total_net = sum(c.stats["network_errors"] for c in self.crawlers)
+        total_bytes = sum(c.stats["bytes"] for c in self.crawlers)
+        elapsed = now - self._prev_time
+        rps = (total_v - self._prev_visited) / elapsed if elapsed > 0 else 0.0
+        fail_pct = total_f / (total_v + total_f) * 100 if (total_v + total_f) > 0 else 0.0
+        self._prev_visited, self._prev_time = total_v, now
+
+        # Alert check
+        alert_active = fail_pct > ALERT_FAIL_THRESHOLD and (total_v + total_f) > 20
+
+        users = []
+        for c in self.crawlers:
+            users.append({
+                "id": c.profile.user_id,
+                "visited": c.stats["visited"],
+                "failed": c.stats["failed"],
+                "client_errors": c.stats["client_errors"],
+                "server_errors": c.stats["server_errors"],
+                "network_errors": c.stats["network_errors"],
+                "queued": c.stats["queued"],
+                "bytes": c.stats["bytes"],
+                "ua": c.profile.ua[:80],
+                "diurnal_weight": round(c.profile.diurnal_weight(), 2),
+            })
+
+        # Diurnal curve (24 points)
+        hour_now = time.localtime().tm_hour + time.localtime().tm_min / 60
+        diurnal_curve = []
+        for h in range(24):
+            diurnal_curve.append({"hour": h, "weight": round(_diurnal_weight(h), 2)})
+
+        # Bandwidth
+        uptime_s = now - self._start_time
+        bw_kbps = (total_bytes / 1024) / uptime_s if uptime_s > 0 else 0
+
+        return {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "uptime_seconds": round(uptime_s),
+            "aggregate": {
+                "visited": total_v,
+                "failed": total_f,
+                "client_errors": total_4xx,
+                "server_errors": total_5xx,
+                "network_errors": total_net,
+                "queued": total_q,
+                "rps": round(rps, 2),
+                "fail_pct": round(fail_pct, 2),
+                "unique_urls": len(self.shared_visited),
+                "active_domains": self.rate_limiter.active_domains_count(),
+                "total_bytes": total_bytes,
+                "bandwidth_kbps": round(bw_kbps, 1),
+                "alert_active": alert_active,
+            },
+            "users": users,
+            "diurnal_curve": diurnal_curve,
+            "current_hour": round(hour_now, 1),
+            "top_domains": self.shared_metrics.top_domains(20),
+            "tld_distribution": self.shared_metrics.tld_distribution(),
+            "recent_errors": list(self.shared_metrics.recent_errors),
+            "request_log": [
+                {"ts": e.ts, "user_id": e.user_id, "url": e.url[:100],
+                 "domain": e.domain, "status": e.status, "bytes": e.bytes}
+                for e in list(self.shared_metrics.request_log)[-50:]
+            ],
+            "fingerprint": self.shared_metrics.fingerprint_score(),
+            "paused": self.shared_metrics.is_paused,
+        }
+
+    def get_runtime_config(self) -> dict:
+        if not self.crawlers:
+            return {}
+        c = self.crawlers[0]
+        return {
+            "num_users": len(self.crawlers),
+            "min_sleep": c.min_sleep,
+            "max_sleep": c.max_sleep,
+            "max_depth": c.max_depth,
+            "concurrency": c.concurrency,
+            "max_links_per_page": c.max_links_per_page,
+            "domain_delay": self.rate_limiter._domain_delay,
+        }
+
+    def apply_config(self, data: dict) -> list:
+        errors = []
+        safe = {}
+        for key, cast, lo, hi in [
+            ("min_sleep", float, 0.1, 300),
+            ("max_sleep", float, 0.1, 600),
+            ("max_depth", int, 1, 50),
+            ("max_links_per_page", int, 1, 500),
+            ("domain_delay", float, 0, 120),
+        ]:
+            if key in data:
+                try:
+                    v = cast(data[key])
+                    if not (lo <= v <= hi):
+                        errors.append(f"{key}: doit être entre {lo} et {hi}")
+                    else:
+                        safe[key] = v
+                except (ValueError, TypeError):
+                    errors.append(f"{key}: valeur invalide")
+        if errors:
+            return errors
+        for c in self.crawlers:
+            if "min_sleep" in safe:
+                c.min_sleep = safe["min_sleep"]
+            if "max_sleep" in safe:
+                c.max_sleep = safe["max_sleep"]
+            if "max_depth" in safe:
+                c.max_depth = safe["max_depth"]
+            if "max_links_per_page" in safe:
+                c.max_links_per_page = safe["max_links_per_page"]
+        if "domain_delay" in safe:
+            self.rate_limiter.domain_delay = safe["domain_delay"]
+        return []
+
+    def prometheus_metrics(self) -> str:
+        lines = []
+        total_v = sum(c.stats["visited"] for c in self.crawlers)
+        total_f = sum(c.stats["failed"] for c in self.crawlers)
+        total_4xx = sum(c.stats["client_errors"] for c in self.crawlers)
+        total_5xx = sum(c.stats["server_errors"] for c in self.crawlers)
+        total_net = sum(c.stats["network_errors"] for c in self.crawlers)
+        total_bytes = sum(c.stats["bytes"] for c in self.crawlers)
+        lines.append(f"# HELP noisy_requests_total Total HTTP requests")
+        lines.append(f"# TYPE noisy_requests_total counter")
+        lines.append(f'noisy_requests_total{{status="ok"}} {total_v}')
+        lines.append(f'noisy_requests_total{{status="client_error"}} {total_4xx}')
+        lines.append(f'noisy_requests_total{{status="server_error"}} {total_5xx}')
+        lines.append(f'noisy_requests_total{{status="network_error"}} {total_net}')
+        lines.append(f"# HELP noisy_bytes_total Total bytes received")
+        lines.append(f"# TYPE noisy_bytes_total counter")
+        lines.append(f"noisy_bytes_total {total_bytes}")
+        lines.append(f"# HELP noisy_unique_urls Unique URLs visited")
+        lines.append(f"# TYPE noisy_unique_urls gauge")
+        lines.append(f"noisy_unique_urls {len(self.shared_visited)}")
+        lines.append(f"# HELP noisy_active_domains Active domains in rate limiter")
+        lines.append(f"# TYPE noisy_active_domains gauge")
+        lines.append(f"noisy_active_domains {self.rate_limiter.active_domains_count()}")
+        for c in self.crawlers:
+            uid = c.profile.user_id
+            lines.append(f'noisy_user_visited{{user="{uid}"}} {c.stats["visited"]}')
+            lines.append(f'noisy_user_failed{{user="{uid}"}} {c.stats["failed"]}')
+        return "\n".join(lines) + "\n"
+
+
+def create_app(collector: MetricsCollector) -> FastAPI:
+    app = FastAPI(title="Noisy Dashboard", docs_url=None, redoc_url=None)
+
+    _cached_html = (STATIC_DIR / "dashboard.html").read_text(encoding="utf-8")
+
+    @app.get("/", response_class=HTMLResponse)
+    async def index():
+        return HTMLResponse(_cached_html)
+
+    @app.get("/api/metrics")
+    async def metrics():
+        return collector.collect()
+
+    @app.get("/api/export")
+    async def export_metrics():
+        data = collector.collect()
+        return JSONResponse(
+            content=data,
+            headers={"Content-Disposition": "attachment; filename=noisy-metrics.json"},
+        )
+
+    @app.get("/api/config")
+    async def get_config():
+        return collector.get_runtime_config()
+
+    @app.post("/api/config")
+    async def set_config(data: dict):
+        errors = collector.apply_config(data)
+        if errors:
+            return JSONResponse(status_code=400, content={"errors": errors})
+        return {"status": "ok", "config": collector.get_runtime_config()}
+
+    @app.post("/api/pause")
+    async def pause():
+        collector.shared_metrics.pause()
+        log.info("[DASHBOARD] crawlers mis en pause")
+        if collector.webhook_url:
+            await _fire_webhook(collector.webhook_url, "paused", {})
+        return {"paused": True}
+
+    @app.post("/api/resume")
+    async def resume():
+        collector.shared_metrics.resume()
+        log.info("[DASHBOARD] crawlers repris")
+        if collector.webhook_url:
+            await _fire_webhook(collector.webhook_url, "resumed", {})
+        return {"paused": False}
+
+    @app.get("/metrics", response_class=PlainTextResponse)
+    async def prometheus():
+        return PlainTextResponse(collector.prometheus_metrics(), media_type="text/plain; version=0.0.4")
+
+    @app.websocket("/ws/metrics")
+    async def ws_metrics(websocket: WebSocket):
+        await websocket.accept()
+        log.info("[DASHBOARD] client WebSocket connecté")
+        try:
+            while True:
+                data = collector.collect()
+                await websocket.send_text(json.dumps(data))
+                # Webhook alert check
+                if data["aggregate"]["alert_active"] and not collector._alert_fired:
+                    collector._alert_fired = True
+                    if collector.webhook_url:
+                        await _fire_webhook(collector.webhook_url, "alert_high_fail_rate", data["aggregate"])
+                elif not data["aggregate"]["alert_active"]:
+                    collector._alert_fired = False
+                await asyncio.sleep(DASHBOARD_UPDATE_INTERVAL)
+        except WebSocketDisconnect:
+            log.info("[DASHBOARD] client WebSocket déconnecté")
+
+    return app
+
+
+async def _fire_webhook(url: str, event: str, data: dict):
+    """Envoie un webhook POST (http/https uniquement)."""
+    if not url.startswith(("http://", "https://")):
+        log.warning(f"[WEBHOOK] URL invalide ignorée: {url}")
+        return
+    import aiohttp
+    payload = {"event": event, "timestamp": datetime.now(timezone.utc).isoformat(), "data": data}
+    try:
+        async with aiohttp.ClientSession() as session:
+            await session.post(url, json=payload, timeout=aiohttp.ClientTimeout(total=WEBHOOK_TIMEOUT))
+        log.info(f"[WEBHOOK] {event} envoyé à {url}")
+    except Exception as e:
+        log.warning(f"[WEBHOOK] échec {url}: {e}")
+
+
+async def start_dashboard(collector: MetricsCollector, port: int, host: str = "127.0.0.1"):
+    """Lance le serveur uvicorn en tâche de fond asyncio."""
+    import uvicorn
+
+    app = create_app(collector)
+    config = uvicorn.Config(app, host=host, port=port, log_level="warning")
+    server = uvicorn.Server(config)
+    log.info(f"[DASHBOARD] démarré sur http://{host}:{port}")
+    await server.serve()

--- a/noisy_lib/extractor.py
+++ b/noisy_lib/extractor.py
@@ -1,0 +1,43 @@
+# extractor.py - Extraction et filtrage de liens HTML
+# IN: html:str, base_url:str, blacklist:list | OUT: List[str] URLs | MODIFIE: rien
+# APPELÉ PAR: crawler.py | APPELLE: html.parser (stdlib)
+
+import logging
+from html.parser import HTMLParser
+from typing import List, Optional
+from urllib.parse import urljoin
+
+log = logging.getLogger(__name__)
+
+
+class LinkExtractor(HTMLParser):
+    def __init__(self, base_url: str):
+        super().__init__()
+        self.base_url = base_url
+        self.links: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs):
+        attr_dict = dict(attrs)
+        if tag == "base" and "href" in attr_dict:
+            self.base_url = attr_dict["href"]
+        elif tag == "a" and "href" in attr_dict:
+            resolved = urljoin(self.base_url, attr_dict["href"])
+            resolved = resolved.split("#")[0]
+            if resolved.startswith("http"):
+                self.links.append(resolved)
+
+
+def extract_links(html: str, base_url: str, blacklist: Optional[List[str]] = None) -> List[str]:
+    """Extrait les liens http(s) du HTML, filtre la blacklist."""
+    parser = LinkExtractor(base_url)
+    try:
+        parser.feed(html)
+    except (ValueError, RuntimeError) as e:
+        log.debug(f"[WARN] parsing | url={base_url} {e}")
+    except Exception as e:
+        log.error(f"[ERREUR] parsing | url={base_url} {e}")
+
+    links = parser.links
+    if blacklist:
+        links = [lnk for lnk in links if not any(b in lnk for b in blacklist)]
+    return links

--- a/noisy_lib/fetch_client.py
+++ b/noisy_lib/fetch_client.py
@@ -1,0 +1,74 @@
+# fetch_client.py - Requête HTTP avec retry exponentiel
+# IN: session, url:str, headers:dict | OUT: FetchResult | MODIFIE: rien
+# APPELÉ PAR: crawler.py | APPELLE: aiohttp, config, profiles.SSL_CONTEXT
+
+import asyncio
+import logging
+import ssl
+from typing import Optional
+
+import aiohttp
+
+from .config import MAX_RESPONSE_BYTES, MAX_RETRIES, REQUEST_TIMEOUT, RETRY_BASE_DELAY
+from .profiles import SSL_CONTEXT
+
+log = logging.getLogger(__name__)
+
+
+class FetchResult:
+    """Résultat d'un fetch : html, status, bytes, ou erreur réseau."""
+    __slots__ = ("html", "status", "bytes_received", "error_msg")
+
+    def __init__(self, html: Optional[str], status: int, bytes_received: int = 0, error_msg: str = ""):
+        self.html = html
+        self.status = status
+        self.bytes_received = bytes_received
+        self.error_msg = error_msg
+
+    @property
+    def ok(self) -> bool:
+        return self.html is not None
+
+    @property
+    def is_client_error(self) -> bool:
+        return 400 <= self.status < 500
+
+    @property
+    def is_server_error(self) -> bool:
+        return self.status >= 500
+
+
+async def fetch_with_retry(
+    session: aiohttp.ClientSession,
+    url: str,
+    headers: dict,
+) -> FetchResult:
+    """GET avec backoff exponentiel (MAX_RETRIES tentatives). Retourne FetchResult."""
+    timeout = aiohttp.ClientTimeout(total=REQUEST_TIMEOUT)
+    last_exc: Optional[Exception] = None
+
+    for attempt in range(MAX_RETRIES):
+        try:
+            async with session.get(
+                url, headers=headers, timeout=timeout,
+                ssl=SSL_CONTEXT, allow_redirects=True,
+            ) as resp:
+                if resp.status >= 500:
+                    if attempt < MAX_RETRIES - 1:
+                        await asyncio.sleep(RETRY_BASE_DELAY * (2 ** attempt))
+                        continue
+                    return FetchResult(None, resp.status, error_msg=f"HTTP {resp.status}")
+                if resp.status >= 400:
+                    return FetchResult(None, resp.status, error_msg=f"HTTP {resp.status}")
+                raw = await resp.content.read(MAX_RESPONSE_BYTES)
+                html = raw.decode(resp.charset or "utf-8", errors="replace")
+                return FetchResult(html, resp.status, bytes_received=len(raw))
+        except (aiohttp.ClientError, asyncio.TimeoutError, ssl.SSLError) as e:
+            last_exc = e
+            log.debug(f"[RETRY] attempt={attempt + 1}/{MAX_RETRIES} url={url} err={e}")
+            if attempt < MAX_RETRIES - 1:
+                await asyncio.sleep(RETRY_BASE_DELAY * (2 ** attempt))
+
+    if last_exc:
+        raise last_exc
+    return FetchResult(None, 0)

--- a/noisy_lib/fetchers.py
+++ b/noisy_lib/fetchers.py
@@ -1,0 +1,99 @@
+# fetchers.py - Récupération données distantes (CRUX, user agents)
+# IN: aiohttp.Session, count:int | OUT: List[str] | MODIFIE: rien
+# APPELÉ PAR: noisy.py, workers.py | APPELLE: aiohttp, config, profiles
+
+import asyncio
+import csv
+import gzip
+import json
+import logging
+import random
+import re
+import ssl
+from typing import List
+
+import aiohttp
+
+from .config import CRUX_TOP_CSV, DEFAULT_CRUX_COUNT, DEFAULT_UA_COUNT, MAX_RESPONSE_BYTES, UA_PAGE_URL
+from .profiles import SSL_CONTEXT, _UA_FALLBACK
+
+log = logging.getLogger(__name__)
+
+
+async def fetch_crux_top_sites(
+    session: aiohttp.ClientSession,
+    count: int = DEFAULT_CRUX_COUNT,
+) -> List[str]:
+    """Charge les top sites CRUX depuis GitHub (CSV gzip)."""
+    log.info(f"[DEBUT] fetch_crux_top_sites | count={count}")
+    try:
+        async with session.get(CRUX_TOP_CSV, ssl=SSL_CONTEXT, timeout=aiohttp.ClientTimeout(total=30)) as resp:
+            if resp.status >= 400:
+                log.error(f"[ERREUR] fetch_crux_top_sites | status={resp.status}")
+                return []
+            data = await resp.read()
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        log.error(f"[ERREUR] fetch_crux_top_sites | {e}")
+        return []
+
+    try:
+        csv_text = gzip.decompress(data).decode()
+    except (OSError, ValueError) as e:
+        log.error(f"[ERREUR] fetch_crux_top_sites decompress | {e}")
+        return []
+
+    reader = csv.DictReader(csv_text.splitlines())
+    sites, seen = [], set()
+    for row in reader:
+        origin = row.get("origin")
+        if origin and origin not in seen:
+            seen.add(origin)
+            sites.append(origin if origin.startswith("http") else f"https://{origin}")
+        if len(sites) >= count:
+            break
+
+    log.info(f"[FIN] fetch_crux_top_sites | loaded={len(sites)}")
+    return sites
+
+
+async def fetch_user_agents(
+    session: aiohttp.ClientSession,
+    count: int = DEFAULT_UA_COUNT,
+) -> List[str]:
+    """Scrape les user agents réels depuis useragents.me."""
+    log.info("[DEBUT] fetch_user_agents")
+    rng = random.Random()
+    try:
+        async with session.get(
+            UA_PAGE_URL, timeout=aiohttp.ClientTimeout(total=15),
+            ssl=SSL_CONTEXT, headers={"User-Agent": rng.choice(_UA_FALLBACK)},
+        ) as resp:
+            if resp.status >= 400:
+                log.warning(f"[WARN] fetch_user_agents | status={resp.status}")
+                return []
+            raw = await resp.content.read(MAX_RESPONSE_BYTES)
+            text = raw.decode(resp.charset or "utf-8", errors="replace")
+
+        agents, seen = [], set()
+        for block in re.findall(r"\[\s*\{[^\[\]]+\}\s*\]", text):
+            try:
+                for entry in json.loads(block):
+                    ua = entry.get("ua", "").strip()
+                    if ua and ua not in seen:
+                        seen.add(ua)
+                        agents.append(ua)
+            except (json.JSONDecodeError, AttributeError):
+                continue
+
+        if not agents:
+            raise ValueError("Aucun UA trouvé sur useragents.me")
+        result = agents[:count]
+        log.info(f"[FIN] fetch_user_agents | loaded={len(result)}")
+        return result
+
+    except (aiohttp.ClientError, asyncio.TimeoutError, ssl.SSLError) as e:
+        log.warning(f"[WARN] fetch_user_agents réseau | {e}")
+        return []
+    except Exception as e:
+        log.error(f"[ERREUR] fetch_user_agents | {e}")
+        return []

--- a/noisy_lib/profiles.py
+++ b/noisy_lib/profiles.py
@@ -1,0 +1,113 @@
+# profiles.py - Profils utilisateurs, pool UA, modèle diurnal
+# IN: user_id, ua:str, rng | OUT: UserProfile, UAPool | MODIFIE: pool interne
+# APPELÉ PAR: noisy.py, crawler.py, workers.py | APPELLE: rien (stdlib)
+
+import asyncio
+import logging
+import math
+import random
+import ssl
+import time
+from typing import List, Optional
+
+log = logging.getLogger(__name__)
+
+try:
+    import brotli as _brotli
+    _BR_SUPPORTED = True
+except ImportError:
+    _BR_SUPPORTED = False
+
+_ACCEPT_ENCODING = "gzip, deflate, br" if _BR_SUPPORTED else "gzip, deflate"
+
+ACCEPT_HEADERS_POOL = [
+    {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8",
+     "Accept-Language": "en-US,en;q=0.9", "Accept-Encoding": _ACCEPT_ENCODING,
+     "Cache-Control": "no-cache", "Pragma": "no-cache", "Upgrade-Insecure-Requests": "1"},
+    {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+     "Accept-Language": "en-GB,en;q=0.8,en-US;q=0.6", "Accept-Encoding": _ACCEPT_ENCODING,
+     "Cache-Control": "max-age=0", "Upgrade-Insecure-Requests": "1"},
+    {"Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8",
+     "Accept-Language": "en-US,en;q=0.7", "Accept-Encoding": _ACCEPT_ENCODING,
+     "Upgrade-Insecure-Requests": "1"},
+]
+
+_UA_FALLBACK = [
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/121.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.3; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "Mozilla/5.0 (X11; Linux x86_64; rv:123.0) Gecko/20100101 Firefox/123.0",
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Safari/537.36 Edg/122.0.0.0",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_3_1) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.3.1 Safari/605.1.15",
+    "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/122.0.0.0 Mobile Safari/537.36",
+]
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    ctx = ssl.create_default_context()
+    ctx.options |= getattr(ssl, "OP_LEGACY_SERVER_CONNECT", 0)
+    return ctx
+
+
+SSL_CONTEXT = _build_ssl_context()
+
+
+def _diurnal_weight(hour: float) -> float:
+    """Poids d'activité selon l'heure locale (0.05–1.0)."""
+    t = (hour - 4) / 24 * 2 * math.pi
+    daytime = 0.5 + 0.5 * math.cos(t + math.pi)
+    evening_boost = max(0.0, math.cos((hour - 20) / 6 * math.pi) * 0.4)
+    return max(0.05, min(1.0, daytime + evening_boost))
+
+
+def _activity_pause_seconds(rng: random.Random) -> float:
+    """5% de chance de pause AFK (5–30 min)."""
+    return rng.uniform(300, 1800) if rng.random() < 0.05 else 0.0
+
+
+class UserProfile:
+    """Empreinte de navigation par utilisateur virtuel."""
+
+    def __init__(self, user_id: int, ua: str, rng: random.Random):
+        self.user_id = user_id
+        self.ua = ua
+        self.rng = rng
+        self.accept_headers = rng.choice(ACCEPT_HEADERS_POOL).copy()
+        self.sleep_phase_offset = rng.uniform(-1.5, 1.5)
+
+    def get_headers(self, referrer: Optional[str] = None) -> dict:
+        h = {**self.accept_headers, "User-Agent": self.ua}
+        if referrer:
+            h["Referer"] = referrer
+        return h
+
+    def diurnal_weight(self) -> float:
+        hour = time.localtime().tm_hour + time.localtime().tm_min / 60
+        return _diurnal_weight((hour + self.sleep_phase_offset) % 24)
+
+
+class UAPool:
+    """Pool thread-safe de user agents avec remplacement async."""
+
+    def __init__(self, initial: List[str]):
+        self._pool: List[str] = list(initial)
+        self._lock = asyncio.Lock()
+
+    def get_random(self, rng: Optional[random.Random] = None) -> str:
+        return (rng or random).choice(self._pool)
+
+    def sample(self, n: int, rng: Optional[random.Random] = None) -> List[str]:
+        r = rng or random.Random()
+        return r.sample(self._pool, n) if len(self._pool) >= n else [r.choice(self._pool) for _ in range(n)]
+
+    async def replace(self, agents: List[str]) -> None:
+        log.info(f"[DEBUT] UAPool.replace | count={len(agents)}")
+        async with self._lock:
+            self._pool = list(agents)
+        log.info(f"[FIN] UAPool.replace")
+
+    def __len__(self) -> int:
+        return len(self._pool)

--- a/noisy_lib/rate_limiter.py
+++ b/noisy_lib/rate_limiter.py
@@ -1,0 +1,54 @@
+# rate_limiter.py - Délai entre requêtes par domaine
+# IN: domain:str, rng | OUT: none (await) | MODIFIE: TTLDict interne, dict locks
+# APPELÉ PAR: crawler.py | APPELLE: structures.TTLDict
+
+import asyncio
+import logging
+import time
+
+from .config import DEFAULT_DOMAIN_DELAY
+from .structures import TTLDict
+
+log = logging.getLogger(__name__)
+
+MAX_LOCKS = 50_000
+
+
+class DomainRateLimiter:
+    """Limite partagée entre tous les crawlers pour un même domaine."""
+
+    def __init__(self, domain_delay: float = DEFAULT_DOMAIN_DELAY):
+        self._domain_delay = domain_delay
+        self._access: TTLDict = TTLDict(ttl=domain_delay * 10, maxsize=50_000)
+        self._locks: dict = {}
+
+    @property
+    def domain_delay(self) -> float:
+        return self._domain_delay
+
+    @domain_delay.setter
+    def domain_delay(self, value: float):
+        self._domain_delay = value
+
+    def active_domains_count(self) -> int:
+        return len(self._access)
+
+    def _get_lock(self, domain: str) -> asyncio.Lock:
+        if domain not in self._locks:
+            if len(self._locks) >= MAX_LOCKS:
+                oldest = next(iter(self._locks))
+                del self._locks[oldest]
+            self._locks[domain] = asyncio.Lock()
+        return self._locks[domain]
+
+    async def wait(self, domain: str, rng) -> None:
+        """Attend le délai minimal avant d'accéder au domaine."""
+        lock = self._get_lock(domain)
+        async with lock:
+            now = time.monotonic()
+            last = self._access.get(domain, 0)
+            wait_time = max(0.0, self._domain_delay * rng.uniform(0.8, 1.2) - (now - last))
+            if wait_time > 0:
+                log.debug(f"[WAIT] domain={domain} wait={wait_time:.2f}s")
+                await asyncio.sleep(wait_time)
+            self._access.set(domain, time.monotonic())

--- a/noisy_lib/static/dashboard.html
+++ b/noisy_lib/static/dashboard.html
@@ -1,0 +1,605 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>NOISY // Dashboard</title>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;700&display=swap" rel="stylesheet">
+<style>
+:root {
+  --bg: #0a0a0f;
+  --surface: #12121a;
+  --surface2: #161620;
+  --border: #1e1e2e;
+  --text: #c8c8d4;
+  --text-dim: #5a5a72;
+  --accent: #00ff88;
+  --accent-dim: #00ff8822;
+  --warn: #ff6b35;
+  --fail: #ff3366;
+  --info: #3388ff;
+  --purple: #aa88ff;
+  --glow: 0 0 20px #00ff8833;
+  --scanline: repeating-linear-gradient(0deg,transparent,transparent 2px,#00ff8803 2px,#00ff8803 4px);
+}
+:root.light {
+  --bg: #f0f0f5;
+  --surface: #ffffff;
+  --surface2: #f5f5fa;
+  --border: #ddd;
+  --text: #222;
+  --text-dim: #888;
+  --accent: #00aa55;
+  --accent-dim: #00aa5522;
+  --warn: #cc5500;
+  --fail: #cc2244;
+  --info: #2266cc;
+  --purple: #7755cc;
+  --glow: 0 0 10px #00aa5533;
+  --scanline: none;
+}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: var(--bg); color: var(--text);
+  font-family: 'JetBrains Mono', monospace; font-size: 13px;
+  min-height: 100vh; overflow-x: hidden;
+}
+body::after {
+  content: ''; position: fixed; inset: 0; background: var(--scanline);
+  pointer-events: none; z-index: 9999; opacity: 0.3;
+}
+/* HEADER */
+.header {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 12px 20px; border-bottom: 1px solid var(--border); background: var(--surface);
+}
+.header-left { display: flex; align-items: center; gap: 12px; }
+.logo {
+  font-size: 18px; font-weight: 700; letter-spacing: 4px;
+  color: var(--accent); text-shadow: var(--glow);
+}
+.logo::before { content: '//'; color: var(--text-dim); margin-right: 6px; font-weight: 300; }
+.badge {
+  display: flex; align-items: center; gap: 5px; padding: 3px 10px;
+  border: 1px solid var(--border); border-radius: 2px;
+  font-size: 10px; color: var(--text-dim); text-transform: uppercase; letter-spacing: 2px;
+}
+.dot {
+  width: 6px; height: 6px; border-radius: 50%; background: var(--accent);
+  animation: pulse 2s ease-in-out infinite;
+}
+.dot.off { background: var(--fail); animation: none; }
+.dot.paused { background: var(--warn); animation: blink 1s step-end infinite; }
+@keyframes pulse { 0%,100%{opacity:1;box-shadow:0 0 4px var(--accent)}50%{opacity:.4;box-shadow:none} }
+@keyframes blink { 50%{opacity:0} }
+.header-right { display: flex; align-items: center; gap: 10px; }
+.uptime { font-size: 11px; color: var(--text-dim); letter-spacing: 1px; }
+.btn {
+  padding: 4px 10px; border: 1px solid var(--border); background: var(--surface);
+  color: var(--text-dim); font-family: inherit; font-size: 10px;
+  text-transform: uppercase; letter-spacing: 1px; cursor: pointer;
+  transition: all .15s;
+}
+.btn:hover { border-color: var(--accent); color: var(--accent); }
+.btn.active { border-color: var(--warn); color: var(--warn); }
+.btn-group { display: flex; gap: 4px; }
+/* ALERT BANNER */
+.alert-banner {
+  display: none; padding: 8px 20px; background: #ff336622; border-bottom: 1px solid var(--fail);
+  color: var(--fail); font-size: 11px; letter-spacing: 1px; text-transform: uppercase;
+  animation: alertFlash 2s ease-in-out infinite;
+}
+.alert-banner.show { display: flex; align-items: center; gap: 8px; }
+@keyframes alertFlash { 50%{background:#ff336611} }
+/* GRID */
+.grid {
+  display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 1px; background: var(--border); margin: 16px; border: 1px solid var(--border);
+}
+.card {
+  background: var(--surface); padding: 14px; position: relative; overflow: hidden;
+  transition: background .15s; animation: fadeIn .3s ease forwards;
+}
+.card:hover { background: var(--surface2); }
+.card-label {
+  font-size: 9px; text-transform: uppercase; letter-spacing: 2px;
+  color: var(--text-dim); margin-bottom: 4px;
+}
+.card-value { font-size: 24px; font-weight: 700; color: var(--accent); font-variant-numeric: tabular-nums; }
+.card-value.warn { color: var(--warn); }
+.card-value.fail { color: var(--fail); }
+.card-value.info { color: var(--info); }
+.card-value.purple { color: var(--purple); }
+.card-sub { font-size: 10px; color: var(--text-dim); margin-top: 2px; }
+.err-breakdown { display: flex; gap: 4px; margin-top: 6px; }
+.err-tag {
+  font-size: 9px; padding: 1px 5px; border-radius: 2px; font-variant-numeric: tabular-nums;
+}
+.err-tag.c4 { color: var(--warn); border: 1px solid #ff6b3533; }
+.err-tag.c5 { color: var(--fail); border: 1px solid #ff336633; }
+.err-tag.cn { color: var(--purple); border: 1px solid #aa88ff33; }
+.spark { margin-top: 8px; height: 20px; display: flex; align-items: flex-end; gap: 1px; }
+.spark-bar {
+  flex: 1; background: var(--accent-dim); border-top: 1px solid var(--accent);
+  min-height: 1px; transition: height .3s;
+}
+/* FINGERPRINT */
+.fp-bar-wrap { display: flex; align-items: center; gap: 6px; margin-top: 4px; }
+.fp-bar { width: 50px; height: 5px; background: var(--border); border-radius: 1px; overflow: hidden; }
+.fp-fill { height: 100%; transition: width .5s; }
+.fp-fill.good { background: var(--accent); }
+.fp-fill.mid { background: var(--warn); }
+.fp-fill.bad { background: var(--fail); }
+/* SECTIONS */
+.sections { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin: 0 16px 16px; }
+.section { min-width: 0; }
+.section.full { grid-column: 1 / -1; }
+.sec-head {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 8px;
+}
+.sec-title {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 2px;
+  color: var(--text-dim); white-space: nowrap;
+}
+.sec-line { flex: 1; height: 1px; background: var(--border); }
+.sec-box {
+  border: 1px solid var(--border); background: var(--surface); padding: 12px;
+  overflow: auto; max-height: 300px;
+}
+/* GRAPH */
+.graph-canvas {
+  width: 100%; height: 80px; display: flex; align-items: flex-end; gap: 1px;
+}
+.graph-bar {
+  flex: 1; background: linear-gradient(to top, var(--accent), var(--accent-dim));
+  min-height: 1px; transition: height .4s;
+}
+.graph-labels {
+  display: flex; justify-content: space-between; margin-top: 4px;
+  font-size: 9px; color: var(--text-dim);
+}
+/* DIURNAL */
+.diurnal-svg { width: 100%; height: 80px; }
+.diurnal-area { fill: var(--accent-dim); }
+.diurnal-line { fill: none; stroke: var(--accent); stroke-width: 1.5; }
+.diurnal-marker { fill: var(--fail); }
+/* TABLE */
+table { width: 100%; border-collapse: collapse; }
+th {
+  text-align: left; padding: 6px 10px; font-size: 9px; text-transform: uppercase;
+  letter-spacing: 1px; color: var(--text-dim); background: var(--surface);
+  border-bottom: 1px solid var(--border); font-weight: 400; white-space: nowrap;
+}
+td {
+  padding: 5px 10px; border-bottom: 1px solid #14141e;
+  font-variant-numeric: tabular-nums; white-space: nowrap; font-size: 12px;
+}
+tr:hover td { background: var(--surface2); }
+.uid { color: var(--accent); font-weight: 500; }
+.ua-cell { max-width: 200px; overflow: hidden; text-overflow: ellipsis; color: var(--text-dim); font-size: 10px; }
+.tc4 { color: var(--warn); }
+.tc5 { color: var(--fail); }
+.tcn { color: var(--purple); }
+/* DIURNAL INLINE */
+.dbar-w { display: flex; align-items: center; gap: 4px; }
+.dbar { width: 40px; height: 4px; background: var(--border); border-radius: 1px; overflow: hidden; }
+.dfill { height: 100%; background: var(--accent); transition: width .5s; }
+.dval { font-size: 10px; color: var(--text-dim); }
+/* HEALTH BAR */
+.hbar { width: 50px; height: 4px; background: var(--border); border-radius: 1px; overflow: hidden; display: inline-block; vertical-align: middle; margin-right: 4px; }
+.hfill { height: 100%; }
+/* LIVE LOG */
+.log-entry {
+  font-size: 11px; padding: 2px 0; border-bottom: 1px solid #14141e;
+  display: flex; gap: 8px;
+}
+.log-ts { color: var(--text-dim); min-width: 60px; }
+.log-status { min-width: 32px; font-weight: 500; }
+.log-status.ok { color: var(--accent); }
+.log-status.err { color: var(--fail); }
+.log-domain { color: var(--info); min-width: 120px; }
+.log-url { color: var(--text-dim); overflow: hidden; text-overflow: ellipsis; }
+/* ERROR LIST */
+.err-entry { font-size: 11px; padding: 3px 0; border-bottom: 1px solid #14141e; }
+.err-msg { color: var(--fail); }
+.err-url { color: var(--text-dim); font-size: 10px; }
+/* TLD */
+.tld-row { display: flex; align-items: center; gap: 8px; padding: 2px 0; font-size: 11px; }
+.tld-name { min-width: 40px; color: var(--info); }
+.tld-bar { flex: 1; height: 4px; background: var(--border); border-radius: 1px; overflow: hidden; }
+.tld-fill { height: 100%; background: var(--info); }
+.tld-count { min-width: 40px; text-align: right; color: var(--text-dim); }
+/* CONFIG PANEL */
+.config-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; }
+.cfg-field { display: flex; flex-direction: column; gap: 2px; }
+.cfg-label { font-size: 9px; text-transform: uppercase; letter-spacing: 1px; color: var(--text-dim); }
+.cfg-input {
+  background: var(--bg); border: 1px solid var(--border); color: var(--text);
+  padding: 4px 8px; font-family: inherit; font-size: 12px; width: 100%;
+}
+.cfg-input:focus { outline: none; border-color: var(--accent); }
+.cfg-btn {
+  grid-column: 1 / -1; padding: 6px; background: var(--accent-dim); border: 1px solid var(--accent);
+  color: var(--accent); font-family: inherit; font-size: 10px; text-transform: uppercase;
+  letter-spacing: 2px; cursor: pointer;
+}
+.cfg-btn:hover { background: var(--accent); color: var(--bg); }
+/* FOOTER */
+.footer {
+  padding: 10px 20px; border-top: 1px solid var(--border);
+  display: flex; justify-content: space-between;
+  font-size: 9px; color: var(--text-dim); letter-spacing: 1px; text-transform: uppercase;
+}
+.no-data { text-align: center; padding: 20px; color: var(--text-dim); font-size: 11px; letter-spacing: 2px; text-transform: uppercase; }
+@keyframes fadeIn { from{opacity:0;transform:translateY(3px)} to{opacity:1;transform:translateY(0)} }
+@media(max-width:900px) {
+  .sections { grid-template-columns: 1fr; }
+  .grid { grid-template-columns: repeat(3, 1fr); margin: 8px; }
+  .header { flex-wrap: wrap; gap: 8px; }
+}
+@media(max-width:600px) {
+  .grid { grid-template-columns: repeat(2, 1fr); }
+}
+</style>
+</head>
+<body>
+
+<div class="header">
+  <div class="header-left">
+    <div class="logo">NOISY</div>
+    <div class="badge"><span class="dot" id="dot"></span><span id="statusText">connecting</span></div>
+  </div>
+  <div class="header-right">
+    <span class="uptime" id="uptime">00:00:00</span>
+    <div class="btn-group">
+      <button class="btn" id="btnPause" onclick="togglePause()">pause</button>
+      <button class="btn" id="btnTheme" onclick="toggleTheme()">light</button>
+      <button class="btn" onclick="exportMetrics()">export</button>
+    </div>
+  </div>
+</div>
+
+<div class="alert-banner" id="alertBanner">
+  <span>&#x26a0;</span> <span>high failure rate detected</span>
+</div>
+
+<div class="grid">
+  <div class="card">
+    <div class="card-label">Visited</div>
+    <div class="card-value" id="visited">-</div>
+    <div class="spark" id="visitedSpark"></div>
+  </div>
+  <div class="card">
+    <div class="card-label">Failed</div>
+    <div class="card-value fail" id="failed">-</div>
+    <div class="card-sub" id="failPct">0%</div>
+    <div class="err-breakdown">
+      <span class="err-tag c4">4xx <span id="c4">0</span></span>
+      <span class="err-tag c5">5xx <span id="c5">0</span></span>
+      <span class="err-tag cn">net <span id="cn">0</span></span>
+    </div>
+  </div>
+  <div class="card">
+    <div class="card-label">Req/s</div>
+    <div class="card-value info" id="rps">-</div>
+    <div class="spark" id="rpsSpark"></div>
+  </div>
+  <div class="card">
+    <div class="card-label">Queued</div>
+    <div class="card-value warn" id="queued">-</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Unique URLs</div>
+    <div class="card-value" id="uniqueUrls">-</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Domains</div>
+    <div class="card-value" id="activeDomains">-</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Bandwidth</div>
+    <div class="card-value purple" id="bw">-</div>
+    <div class="card-sub" id="bwTotal">0 MB</div>
+  </div>
+  <div class="card">
+    <div class="card-label">Stealth Score</div>
+    <div class="card-value" id="fpScore">-</div>
+    <div class="fp-bar-wrap">
+      <div class="fp-bar"><div class="fp-fill" id="fpFill"></div></div>
+      <span class="card-sub" id="fpLabel">-</span>
+    </div>
+  </div>
+</div>
+
+<div class="sections">
+
+  <div class="section">
+    <div class="sec-head"><span class="sec-title">RPS History</span><span class="sec-line"></span></div>
+    <div class="sec-box">
+      <div class="graph-canvas" id="rpsGraph"></div>
+      <div class="graph-labels"><span>-2min</span><span>req/s</span><span>now</span></div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="sec-head"><span class="sec-title">Diurnal Activity</span><span class="sec-line"></span></div>
+    <div class="sec-box">
+      <svg class="diurnal-svg" id="diurnalSvg" viewBox="0 0 240 80" preserveAspectRatio="none"></svg>
+      <div class="graph-labels"><span>0h</span><span>activity model (24h)</span><span>23h</span></div>
+    </div>
+  </div>
+
+  <div class="section full">
+    <div class="sec-head"><span class="sec-title">Virtual Users</span><span class="sec-line"></span></div>
+    <div class="sec-box" style="max-height:none">
+      <table>
+        <thead><tr>
+          <th>ID</th><th>Visited</th><th>Failed</th><th>4xx</th><th>5xx</th><th>Net</th>
+          <th>Queued</th><th>Data</th><th>Activity</th><th>User Agent</th>
+        </tr></thead>
+        <tbody id="usersBody"><tr><td colspan="10" class="no-data">waiting...</td></tr></tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="sec-head"><span class="sec-title">Top Domains</span><span class="sec-line"></span></div>
+    <div class="sec-box" id="topDomains"><div class="no-data">waiting...</div></div>
+  </div>
+
+  <div class="section">
+    <div class="sec-head"><span class="sec-title">TLD Distribution</span><span class="sec-line"></span></div>
+    <div class="sec-box" id="tldDist"><div class="no-data">waiting...</div></div>
+  </div>
+
+  <div class="section">
+    <div class="sec-head"><span class="sec-title">Live Request Log</span><span class="sec-line"></span></div>
+    <div class="sec-box" id="liveLog" style="max-height:220px"><div class="no-data">waiting...</div></div>
+  </div>
+
+  <div class="section">
+    <div class="sec-head"><span class="sec-title">Recent Errors</span><span class="sec-line"></span></div>
+    <div class="sec-box" id="errList" style="max-height:220px"><div class="no-data">no errors</div></div>
+  </div>
+
+  <div class="section">
+    <div class="sec-head"><span class="sec-title">Runtime Config</span><span class="sec-line"></span></div>
+    <div class="sec-box">
+      <div class="config-grid" id="cfgGrid">
+        <div class="cfg-field"><label class="cfg-label">Min Sleep (s)</label><input class="cfg-input" id="cfgMinSleep" type="number" step="0.5"></div>
+        <div class="cfg-field"><label class="cfg-label">Max Sleep (s)</label><input class="cfg-input" id="cfgMaxSleep" type="number" step="0.5"></div>
+        <div class="cfg-field"><label class="cfg-label">Max Depth</label><input class="cfg-input" id="cfgMaxDepth" type="number" step="1"></div>
+        <div class="cfg-field"><label class="cfg-label">Domain Delay (s)</label><input class="cfg-input" id="cfgDomainDelay" type="number" step="0.5"></div>
+        <div class="cfg-field"><label class="cfg-label">Links/Page</label><input class="cfg-input" id="cfgMaxLinks" type="number" step="5"></div>
+        <div class="cfg-field" style="display:flex;justify-content:center;align-items:flex-end">
+          <span class="card-sub" id="cfgStatus"></span>
+        </div>
+        <button class="cfg-btn" onclick="applyConfig()">Apply Changes</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="section">
+    <div class="sec-head"><span class="sec-title">Stealth Analysis</span><span class="sec-line"></span></div>
+    <div class="sec-box" id="fpDetail"><div class="no-data">waiting...</div></div>
+  </div>
+
+</div>
+
+<div class="footer">
+  <span>noisy traffic generator</span>
+  <span id="lastUpdate">last update: -</span>
+</div>
+
+<script>
+const H = 60, rpsH = [], visH = [];
+let ws, rDelay = 1000, paused = false, cfgLoaded = false;
+
+function fmt(n) {
+  if (n >= 1e6) return (n/1e6).toFixed(1)+'M';
+  if (n >= 1e3) return (n/1e3).toFixed(1)+'K';
+  return String(n);
+}
+function fmtB(b) {
+  if (b >= 1e9) return (b/1e9).toFixed(1)+' GB';
+  if (b >= 1e6) return (b/1e6).toFixed(1)+' MB';
+  if (b >= 1e3) return (b/1e3).toFixed(1)+' KB';
+  return b+' B';
+}
+function fmtUp(s) {
+  const h=Math.floor(s/3600), m=Math.floor((s%3600)/60), sec=s%60;
+  return [h,m,sec].map(v=>String(v).padStart(2,'0')).join(':');
+}
+function spark(el, data) {
+  el.innerHTML='';
+  const p=Math.max(...data,1);
+  data.slice(-20).forEach(v=>{
+    const b=document.createElement('div');b.className='spark-bar';
+    b.style.height=Math.max(1,(v/p)*20)+'px';el.appendChild(b);
+  });
+}
+function rpsGraph(data) {
+  const c=document.getElementById('rpsGraph');c.innerHTML='';
+  const p=Math.max(...data,0.1);
+  data.forEach(v=>{
+    const b=document.createElement('div');b.className='graph-bar';
+    b.style.height=Math.max(1,(v/p)*80)+'px';c.appendChild(b);
+  });
+}
+function diurnalChart(curve, hour) {
+  const svg=document.getElementById('diurnalSvg');
+  const w=240, h=80;
+  let pts=curve.map((c,i)=>[i*(w/23), h-c.weight*h]);
+  let pathD='M'+pts.map(p=>p.join(',')).join('L');
+  let areaD=pathD+'L'+w+','+h+'L0,'+h+'Z';
+  const mx=hour*(w/23), my=h-curve[Math.min(23,Math.floor(hour))].weight*h;
+  svg.innerHTML=`<path class="diurnal-area" d="${areaD}"/><path class="diurnal-line" d="${pathD}"/><circle class="diurnal-marker" cx="${mx}" cy="${my}" r="3"/>`;
+}
+function healthColor(v) { return v>=0.7?'var(--accent)':v>=0.4?'var(--warn)':'var(--fail)'; }
+function fpColor(v) { return v>=0.6?'good':v>=0.3?'mid':'bad'; }
+
+function update(d) {
+  const a=d.aggregate;
+  document.getElementById('visited').textContent=fmt(a.visited);
+  document.getElementById('failed').textContent=fmt(a.failed);
+  document.getElementById('failPct').textContent=a.fail_pct.toFixed(1)+'%';
+  document.getElementById('c4').textContent=fmt(a.client_errors);
+  document.getElementById('c5').textContent=fmt(a.server_errors);
+  document.getElementById('cn').textContent=fmt(a.network_errors);
+  document.getElementById('rps').textContent=a.rps.toFixed(1);
+  document.getElementById('queued').textContent=fmt(a.queued);
+  document.getElementById('uniqueUrls').textContent=fmt(a.unique_urls);
+  document.getElementById('activeDomains').textContent=fmt(a.active_domains);
+  document.getElementById('uptime').textContent=fmtUp(d.uptime_seconds);
+  document.getElementById('bw').textContent=a.bandwidth_kbps.toFixed(0)+' KB/s';
+  document.getElementById('bwTotal').textContent=fmtB(a.total_bytes);
+  // Alert
+  const ab=document.getElementById('alertBanner');
+  ab.classList.toggle('show', a.alert_active);
+  // Pause state
+  const dot=document.getElementById('dot');
+  const btn=document.getElementById('btnPause');
+  if(d.paused){dot.className='dot paused';btn.textContent='resume';btn.classList.add('active');}
+  else{dot.className='dot';btn.textContent='pause';btn.classList.remove('active');}
+  paused=d.paused;
+  // Fingerprint
+  const fp=d.fingerprint;
+  document.getElementById('fpScore').textContent=(fp.overall*100).toFixed(0)+'%';
+  const fpFill=document.getElementById('fpFill');
+  fpFill.style.width=fp.overall*100+'%';
+  fpFill.className='fp-fill '+fpColor(fp.overall);
+  document.getElementById('fpLabel').textContent=fp.overall>=0.6?'natural':fp.overall>=0.3?'moderate':'uniform';
+  // Sparklines
+  rpsH.push(a.rps); if(rpsH.length>H)rpsH.shift();
+  visH.push(a.visited); if(visH.length>H)visH.shift();
+  spark(document.getElementById('rpsSpark'),rpsH);
+  spark(document.getElementById('visitedSpark'),visH);
+  rpsGraph(rpsH);
+  // Diurnal
+  if(d.diurnal_curve) diurnalChart(d.diurnal_curve, d.current_hour);
+  // Users table
+  const tb=document.getElementById('usersBody');
+  if(d.users&&d.users.length){
+    tb.innerHTML=d.users.map(u=>`<tr>
+      <td class="uid">U${u.id}</td><td>${fmt(u.visited)}</td><td>${fmt(u.failed)}</td>
+      <td class="tc4">${fmt(u.client_errors)}</td><td class="tc5">${fmt(u.server_errors)}</td>
+      <td class="tcn">${fmt(u.network_errors)}</td><td>${fmt(u.queued)}</td>
+      <td>${fmtB(u.bytes)}</td>
+      <td><div class="dbar-w"><div class="dbar"><div class="dfill" style="width:${u.diurnal_weight*100}%"></div></div><span class="dval">${u.diurnal_weight}</span></div></td>
+      <td class="ua-cell" title="${u.ua}">${u.ua}</td>
+    </tr>`).join('');
+  }
+  // Top domains
+  const td=document.getElementById('topDomains');
+  if(d.top_domains&&d.top_domains.length){
+    td.innerHTML='<table><thead><tr><th>Domain</th><th>OK</th><th>Fail</th><th>Health</th><th>Data</th></tr></thead><tbody>'
+      +d.top_domains.slice(0,15).map(dm=>`<tr>
+        <td style="color:var(--info)">${dm.domain}</td><td>${dm.ok}</td><td>${dm.fail}</td>
+        <td><span class="hbar"><span class="hfill" style="width:${dm.health*100}%;background:${healthColor(dm.health)}"></span></span>${(dm.health*100).toFixed(0)}%</td>
+        <td>${fmtB(dm.bytes)}</td>
+      </tr>`).join('')+'</tbody></table>';
+  }
+  // TLD dist
+  const tl=document.getElementById('tldDist');
+  if(d.tld_distribution&&d.tld_distribution.length){
+    const maxC=d.tld_distribution[0].count;
+    tl.innerHTML=d.tld_distribution.map(t=>`<div class="tld-row">
+      <span class="tld-name">${t.tld}</span>
+      <div class="tld-bar"><div class="tld-fill" style="width:${(t.count/maxC)*100}%"></div></div>
+      <span class="tld-count">${fmt(t.count)}</span>
+    </div>`).join('');
+  }
+  // Live log
+  const ll=document.getElementById('liveLog');
+  if(d.request_log&&d.request_log.length){
+    ll.innerHTML=d.request_log.slice(-30).reverse().map(r=>{
+      const t=new Date(r.ts*1000);
+      const sc=r.status>=200&&r.status<400?'ok':'err';
+      return `<div class="log-entry">
+        <span class="log-ts">${t.toLocaleTimeString()}</span>
+        <span class="log-status ${sc}">${r.status||'ERR'}</span>
+        <span class="log-domain">${r.domain}</span>
+        <span class="log-url">${r.url}</span>
+      </div>`;
+    }).join('');
+  }
+  // Errors
+  const el=document.getElementById('errList');
+  if(d.recent_errors&&d.recent_errors.length){
+    el.innerHTML=d.recent_errors.slice(-20).reverse().map(e=>{
+      const t=new Date(e.ts*1000);
+      return `<div class="err-entry">
+        <span class="log-ts">${t.toLocaleTimeString()}</span>
+        <span class="err-msg"> U${e.user_id} ${e.error}</span>
+        <div class="err-url">${e.url}</div>
+      </div>`;
+    }).join('');
+  } else { el.innerHTML='<div class="no-data">no errors</div>'; }
+  // Fingerprint detail
+  const fpd=document.getElementById('fpDetail');
+  fpd.innerHTML=['domain_diversity','tld_diversity','timing_variance'].map(k=>{
+    const v=fp[k];
+    return `<div class="fp-bar-wrap" style="margin:6px 0">
+      <span style="min-width:120px;font-size:11px;color:var(--text-dim)">${k.replace('_',' ')}</span>
+      <div class="fp-bar" style="width:80px"><div class="fp-fill ${fpColor(v)}" style="width:${v*100}%"></div></div>
+      <span style="font-size:11px">${(v*100).toFixed(0)}%</span>
+    </div>`;
+  }).join('');
+  // Config (load once)
+  if(!cfgLoaded&&d.users){cfgLoaded=true;loadConfig();}
+  // Timestamp
+  document.getElementById('lastUpdate').textContent='last update: '+new Date(d.timestamp).toLocaleTimeString();
+}
+
+function setStatus(on){
+  document.getElementById('dot').className='dot'+(on?'':' off');
+  document.getElementById('statusText').textContent=on?'live':'reconnecting';
+}
+function connect(){
+  const p=location.protocol==='https:'?'wss:':'ws:';
+  ws=new WebSocket(`${p}//${location.host}/ws/metrics`);
+  ws.onopen=()=>{setStatus(true);rDelay=1000;};
+  ws.onmessage=e=>{try{update(JSON.parse(e.data))}catch(x){console.error(x)}};
+  ws.onclose=()=>{setStatus(false);setTimeout(connect,rDelay);rDelay=Math.min(rDelay*1.5,10000);};
+  ws.onerror=()=>ws.close();
+}
+function togglePause(){
+  fetch('/api/'+(paused?'resume':'pause'),{method:'POST'});
+}
+function toggleTheme(){
+  const r=document.documentElement;
+  const light=r.classList.toggle('light');
+  document.getElementById('btnTheme').textContent=light?'dark':'light';
+}
+function exportMetrics(){
+  window.open('/api/export','_blank');
+}
+async function loadConfig(){
+  try{
+    const r=await fetch('/api/config');
+    const c=await r.json();
+    document.getElementById('cfgMinSleep').value=c.min_sleep;
+    document.getElementById('cfgMaxSleep').value=c.max_sleep;
+    document.getElementById('cfgMaxDepth').value=c.max_depth;
+    document.getElementById('cfgDomainDelay').value=c.domain_delay;
+    document.getElementById('cfgMaxLinks').value=c.max_links_per_page;
+  }catch(e){}
+}
+async function applyConfig(){
+  const data={
+    min_sleep:parseFloat(document.getElementById('cfgMinSleep').value),
+    max_sleep:parseFloat(document.getElementById('cfgMaxSleep').value),
+    max_depth:parseInt(document.getElementById('cfgMaxDepth').value),
+    domain_delay:parseFloat(document.getElementById('cfgDomainDelay').value),
+    max_links_per_page:parseInt(document.getElementById('cfgMaxLinks').value),
+  };
+  try{
+    await fetch('/api/config',{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(data)});
+    document.getElementById('cfgStatus').textContent='applied!';
+    setTimeout(()=>document.getElementById('cfgStatus').textContent='',2000);
+  }catch(e){document.getElementById('cfgStatus').textContent='error';}
+}
+connect();
+</script>
+</body>
+</html>

--- a/noisy_lib/structures.py
+++ b/noisy_lib/structures.py
@@ -1,0 +1,90 @@
+# structures.py - Collections LRU et TTL bornées
+# IN: items/clés/valeurs | OUT: items/valeurs | MODIFIE: état interne OrderedDict
+# APPELÉ PAR: crawler.py, rate_limiter.py | APPELLE: rien (stdlib)
+
+import logging
+import time
+from collections import OrderedDict
+
+log = logging.getLogger(__name__)
+
+
+class LRUSet:
+    """Ensemble borné avec éviction LRU."""
+
+    def __init__(self, maxsize: int):
+        self._data: OrderedDict = OrderedDict()
+        self._maxsize = maxsize
+
+    def __contains__(self, item) -> bool:
+        return item in self._data
+
+    def add(self, item):
+        if item in self._data:
+            self._data.move_to_end(item)
+            return
+        self._data[item] = None
+        if len(self._data) > self._maxsize:
+            self._data.popitem(last=False)
+
+    def discard(self, item):
+        self._data.pop(item, None)
+
+    def __len__(self) -> int:
+        return len(self._data)
+
+
+class BoundedDict:
+    """Dict borné avec éviction LRU."""
+
+    def __init__(self, maxsize: int):
+        self._data: OrderedDict = OrderedDict()
+        self._maxsize = maxsize
+
+    def get(self, key, default=None):
+        return self._data.get(key, default)
+
+    def set(self, key, value):
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = value
+        if len(self._data) > self._maxsize:
+            self._data.popitem(last=False)
+
+    def pop(self, key, default=None):
+        return self._data.pop(key, default)
+
+    def __contains__(self, key):
+        return key in self._data
+
+
+class TTLDict:
+    """Dict avec expiration automatique par TTL (secondes)."""
+
+    def __init__(self, ttl: float, maxsize: int):
+        self._data: OrderedDict = OrderedDict()
+        self._times: dict = {}
+        self._ttl = ttl
+        self._maxsize = maxsize
+
+    def get(self, key, default=None):
+        self._maybe_evict(key)
+        return self._data.get(key, default)
+
+    def set(self, key, value):
+        now = time.monotonic()
+        self._data[key] = value
+        self._times[key] = now
+        self._data.move_to_end(key)
+        while len(self._data) > self._maxsize:
+            oldest = next(iter(self._data))
+            del self._data[oldest]
+            del self._times[oldest]
+
+    def __len__(self):
+        return len(self._data)
+
+    def _maybe_evict(self, key):
+        if key in self._times and time.monotonic() - self._times[key] > self._ttl:
+            del self._data[key]
+            del self._times[key]

--- a/noisy_lib/workers.py
+++ b/noisy_lib/workers.py
@@ -1,0 +1,115 @@
+# workers.py - Tâches fond : DNS bruit, stats, refresh UA
+# IN: domains, crawlers, stop_event | OUT: none | MODIFIE: UAPool, profiles.ua
+# APPELÉ PAR: noisy.py | APPELLE: fetchers, profiles, config
+
+import asyncio
+import logging
+import random
+import socket
+import time
+from typing import List, TYPE_CHECKING
+
+from .config import DEFAULT_DNS_MAX_SLEEP, DEFAULT_DNS_MIN_SLEEP
+from .fetchers import fetch_user_agents
+from .profiles import _diurnal_weight
+
+if TYPE_CHECKING:
+    from .crawler import UserCrawler
+    from .profiles import UAPool
+
+log = logging.getLogger(__name__)
+
+
+async def dns_noise_worker(
+    domains: List[str],
+    stop_event: asyncio.Event,
+    min_sleep: float = DEFAULT_DNS_MIN_SLEEP,
+    max_sleep: float = DEFAULT_DNS_MAX_SLEEP,
+    worker_id: int = 0,
+) -> None:
+    """Résout des domaines aléatoires sans connexion HTTP (bruit DNS)."""
+    log.info(f"[DEBUT] dns_noise_worker | id={worker_id} domains={len(domains)}")
+    rng = random.Random()
+    loop = asyncio.get_event_loop()
+    while not stop_event.is_set():
+        host = rng.choice(domains)
+        try:
+            await loop.getaddrinfo(host, None, proto=socket.IPPROTO_TCP)
+            log.debug(f"[DNS] resolved={host}")
+        except Exception as e:
+            log.debug(f"[DNS] failed={host} {e}")
+        hour = time.localtime().tm_hour + time.localtime().tm_min / 60
+        scale = 1.0 / max(0.1, _diurnal_weight(hour))
+        await asyncio.sleep(rng.uniform(min_sleep, max_sleep) * scale)
+
+
+async def stats_reporter(crawlers: List["UserCrawler"], stop_event: asyncio.Event) -> None:
+    """Rapporte les stats toutes les 60s : visités, échecs %, req/s."""
+    prev_visited = 0
+    prev_time = time.monotonic()
+    while not stop_event.is_set():
+        await asyncio.sleep(60)
+        now = time.monotonic()
+        total_v = sum(c.stats["visited"] for c in crawlers)
+        total_f = sum(c.stats["failed"] for c in crawlers)
+        total_q = sum(c.stats["queued"] for c in crawlers)
+        rps = (total_v - prev_visited) / (now - prev_time)
+        fail_pct = total_f / (total_v + total_f) * 100 if (total_v + total_f) > 0 else 0.0
+        per_user = " | ".join(f"u{c.profile.user_id}:{c.stats['visited']}v" for c in crawlers)
+        log.info(
+            f"[STATS] visited={total_v} failed={total_f} ({fail_pct:.1f}%) "
+            f"queued={total_q} rps={rps:.2f} | {per_user}"
+        )
+        prev_visited, prev_time = total_v, now
+
+
+async def refresh_user_agents_loop(
+    stop_event: asyncio.Event,
+    ua_refresh_seconds: int,
+    crawlers: List["UserCrawler"],
+    ua_pool: "UAPool",
+) -> None:
+    """Rafraîchit le pool UA et tourne les agents par utilisateur."""
+    import aiohttp
+    log.info(f"[DEBUT] refresh_user_agents_loop | interval={ua_refresh_seconds}s")
+    await asyncio.sleep(ua_refresh_seconds)
+    async with aiohttp.ClientSession() as session:
+        while not stop_event.is_set():
+            agents = await fetch_user_agents(session)
+            if agents:
+                await ua_pool.replace(agents)
+                for crawler, ua in zip(crawlers, ua_pool.sample(len(crawlers))):
+                    crawler.profile.ua = ua
+            await asyncio.sleep(ua_refresh_seconds)
+
+
+async def http_noise_worker(
+    domains: List[str],
+    stop_event: asyncio.Event,
+    worker_id: int = 0,
+    min_sleep: float = 10,
+    max_sleep: float = 60,
+) -> None:
+    """Envoie des HEAD HTTP aléatoires pour diversifier le mix de méthodes (read-only)."""
+    import aiohttp as _aiohttp
+    from .profiles import SSL_CONTEXT, _UA_FALLBACK
+    log.info(f"[DEBUT] http_noise_worker | id={worker_id}")
+    rng = random.Random()
+    timeout = _aiohttp.ClientTimeout(total=10)
+    async with _aiohttp.ClientSession() as session:
+        while not stop_event.is_set():
+            host = rng.choice(domains)
+            url = f"https://{host}/"
+            ua = rng.choice(_UA_FALLBACK)
+            headers = {"User-Agent": ua}
+            try:
+                async with session.head(
+                    url, headers=headers,
+                    timeout=timeout, ssl=SSL_CONTEXT, allow_redirects=False,
+                ) as resp:
+                    log.debug(f"[HEAD] host={host} status={resp.status}")
+            except Exception:
+                pass
+            hour = time.localtime().tm_hour + time.localtime().tm_min / 60
+            scale = 1.0 / max(0.1, _diurnal_weight(hour))
+            await asyncio.sleep(rng.uniform(min_sleep, max_sleep) * scale)

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+asyncio_mode = auto
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=7.0
+pytest-asyncio>=0.21

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 aiohttp==3.13.5
 Brotli>=1.1.0
+fastapi>=0.110
+uvicorn[standard]>=0.29

--- a/start.bat
+++ b/start.bat
@@ -1,0 +1,59 @@
+@echo off
+title Noisy - Traffic Generator
+echo.
+echo  ========================================
+echo   NOISY - Traffic Noise Generator
+echo  ========================================
+echo.
+
+:: Check Python
+python --version >nul 2>&1
+if errorlevel 1 (
+    echo  [ERREUR] Python n'est pas installe.
+    echo  Telecharge-le ici : https://www.python.org/downloads/
+    echo.
+    pause
+    exit /b 1
+)
+
+:: Move to script directory
+cd /d "%~dp0"
+
+:: Create venv if missing
+if not exist "venv" (
+    echo  [1/3] Creation de l'environnement virtuel...
+    python -m venv venv
+    if errorlevel 1 (
+        echo  [ERREUR] Impossible de creer le venv.
+        pause
+        exit /b 1
+    )
+)
+
+:: Activate venv
+call venv\Scripts\activate.bat
+
+:: Install deps if needed
+if not exist "venv\.deps_installed" (
+    echo  [2/3] Installation des dependances...
+    pip install -r requirements.txt --quiet
+    if errorlevel 1 (
+        echo  [ERREUR] Installation echouee.
+        pause
+        exit /b 1
+    )
+    echo ok > venv\.deps_installed
+) else (
+    echo  [2/3] Dependances deja installees.
+)
+
+echo  [3/3] Demarrage de Noisy + Dashboard...
+echo.
+echo  Dashboard : http://localhost:8080
+echo  Appuie sur Ctrl+C pour arreter.
+echo.
+
+python noisy.py --dashboard %*
+
+echo.
+pause

--- a/start.command
+++ b/start.command
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Noisy - Traffic Noise Generator (macOS)
+
+echo ""
+echo "  ========================================"
+echo "   NOISY - Traffic Noise Generator"
+echo "  ========================================"
+echo ""
+
+# Move to script directory
+cd "$(dirname "$0")"
+
+# Check Python
+if ! command -v python3 &> /dev/null; then
+    echo "  [ERREUR] Python 3 n'est pas installe."
+    echo "  Telecharge-le ici : https://www.python.org/downloads/"
+    echo ""
+    read -p "  Appuie sur Entree pour fermer..."
+    exit 1
+fi
+
+# Create venv if missing
+if [ ! -d "venv" ]; then
+    echo "  [1/3] Creation de l'environnement virtuel..."
+    python3 -m venv venv
+    if [ $? -ne 0 ]; then
+        echo "  [ERREUR] Impossible de creer le venv."
+        read -p "  Appuie sur Entree pour fermer..."
+        exit 1
+    fi
+fi
+
+# Activate venv
+source venv/bin/activate
+
+# Install deps if needed
+if [ ! -f "venv/.deps_installed" ]; then
+    echo "  [2/3] Installation des dependances..."
+    pip install -r requirements.txt --quiet
+    if [ $? -ne 0 ]; then
+        echo "  [ERREUR] Installation echouee."
+        read -p "  Appuie sur Entree pour fermer..."
+        exit 1
+    fi
+    touch venv/.deps_installed
+else
+    echo "  [2/3] Dependances deja installees."
+fi
+
+echo "  [3/3] Demarrage de Noisy + Dashboard..."
+echo ""
+echo "  Dashboard : http://localhost:8080"
+echo "  Appuie sur Ctrl+C pour arreter."
+echo ""
+
+python noisy.py --dashboard "$@"
+
+echo ""
+read -p "  Appuie sur Entree pour fermer..."

--- a/tests/test_extractor.py
+++ b/tests/test_extractor.py
@@ -1,0 +1,82 @@
+"""Unit tests for HTML link extraction."""
+
+import pytest
+
+from noisy_lib.extractor import LinkExtractor, extract_links
+
+
+class TestLinkExtractor:
+    def test_absolute_link(self):
+        parser = LinkExtractor("https://example.com")
+        parser.feed('<a href="https://other.com/page">link</a>')
+        assert "https://other.com/page" in parser.links
+
+    def test_relative_link_resolved(self):
+        parser = LinkExtractor("https://example.com")
+        parser.feed('<a href="/about">about</a>')
+        assert "https://example.com/about" in parser.links
+
+    def test_base_tag_changes_base(self):
+        parser = LinkExtractor("https://example.com")
+        parser.feed('<base href="https://cdn.example.com/"><a href="file.js">f</a>')
+        assert "https://cdn.example.com/file.js" in parser.links
+
+    def test_non_http_links_excluded(self):
+        parser = LinkExtractor("https://example.com")
+        parser.feed('<a href="mailto:test@example.com">email</a>')
+        assert not any("mailto" in lnk for lnk in parser.links)
+
+    def test_ftp_link_excluded(self):
+        parser = LinkExtractor("https://example.com")
+        parser.feed('<a href="ftp://files.example.com">ftp</a>')
+        assert not any("ftp" in lnk for lnk in parser.links)
+
+
+class TestExtractLinks:
+    def test_returns_list(self):
+        links = extract_links('<a href="https://a.com">a</a>', "https://example.com")
+        assert isinstance(links, list)
+
+    def test_empty_html_returns_empty(self):
+        assert extract_links("", "https://example.com") == []
+
+    def test_no_links_returns_empty(self):
+        assert extract_links("<p>no links here</p>", "https://example.com") == []
+
+    def test_multiple_links(self):
+        html = '<a href="https://a.com">a</a><a href="https://b.com">b</a>'
+        links = extract_links(html, "https://example.com")
+        assert len(links) == 2
+
+    def test_blacklist_filters_matching_urls(self):
+        html = (
+            '<a href="https://example.com/page">ok</a>'
+            '<a href="https://t.co/abc123">blocked</a>'
+        )
+        links = extract_links(html, "https://example.com", blacklist=["t.co"])
+        assert "https://example.com/page" in links
+        assert not any("t.co" in lnk for lnk in links)
+
+    def test_blacklist_extension(self):
+        html = (
+            '<a href="https://example.com/login">login</a>'
+            '<a href="https://example.com/about">about</a>'
+        )
+        links = extract_links(html, "https://example.com", blacklist=["login"])
+        assert not any("login" in lnk for lnk in links)
+        assert any("about" in lnk for lnk in links)
+
+    def test_empty_blacklist_no_filtering(self):
+        html = '<a href="https://t.co/xyz">link</a>'
+        links = extract_links(html, "https://example.com", blacklist=[])
+        assert "https://t.co/xyz" in links
+
+    def test_malformed_html_does_not_raise(self):
+        html = "<a href='https://example.com/unclosed"
+        links = extract_links(html, "https://example.com")
+        assert isinstance(links, list)
+
+    def test_relative_link_in_extract(self):
+        html = '<a href="/contact">contact</a>'
+        links = extract_links(html, "https://example.com")
+        assert "https://example.com/contact" in links

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,110 @@
+"""Unit tests for diurnal weight model and UAPool."""
+
+import random
+
+import pytest
+
+from noisy_lib.profiles import UAPool, UserProfile, _diurnal_weight, _activity_pause_seconds
+
+
+class TestDiurnalWeight:
+    def test_range_all_hours(self):
+        for hour in range(24):
+            w = _diurnal_weight(float(hour))
+            assert 0.05 <= w <= 1.0, f"Weight {w} out of [0.05, 1.0] at hour {hour}"
+
+    def test_fractional_hours(self):
+        for tenth in range(240):
+            hour = tenth / 10.0
+            w = _diurnal_weight(hour)
+            assert 0.05 <= w <= 1.0
+
+    def test_midday_higher_than_midnight(self):
+        assert _diurnal_weight(12.0) > _diurnal_weight(0.0)
+
+    def test_evening_boost_around_9pm(self):
+        evening = _diurnal_weight(21.0)
+        pre_dawn = _diurnal_weight(4.0)
+        assert evening > pre_dawn
+
+    def test_minimum_never_zero(self):
+        for hour in range(24):
+            assert _diurnal_weight(float(hour)) >= 0.05
+
+
+class TestActivityPause:
+    def test_usually_no_pause(self):
+        rng = random.Random(42)
+        pauses = [_activity_pause_seconds(rng) for _ in range(200)]
+        non_zero = [p for p in pauses if p > 0]
+        # Expect roughly 5%; allow generous range 0–15%
+        assert len(non_zero) / len(pauses) < 0.15
+
+    def test_pause_duration_in_range(self):
+        rng = random.Random(0)
+        for _ in range(1000):
+            p = _activity_pause_seconds(rng)
+            if p > 0:
+                assert 300 <= p <= 1800
+
+
+class TestUAPool:
+    def test_get_random_returns_member(self):
+        pool = UAPool(["ua1", "ua2", "ua3"])
+        ua = pool.get_random()
+        assert ua in ["ua1", "ua2", "ua3"]
+
+    def test_sample_correct_count(self):
+        pool = UAPool(["ua1", "ua2", "ua3", "ua4", "ua5"])
+        sampled = pool.sample(3)
+        assert len(sampled) == 3
+
+    def test_sample_with_repeat_when_pool_small(self):
+        pool = UAPool(["ua1", "ua2"])
+        sampled = pool.sample(5)
+        assert len(sampled) == 5
+        assert all(s in ["ua1", "ua2"] for s in sampled)
+
+    def test_len(self):
+        pool = UAPool(["ua1", "ua2", "ua3"])
+        assert len(pool) == 3
+
+    @pytest.mark.asyncio
+    async def test_replace_updates_pool(self):
+        pool = UAPool(["old_ua"])
+        await pool.replace(["new1", "new2", "new3"])
+        assert len(pool) == 3
+        ua = pool.get_random()
+        assert ua in ["new1", "new2", "new3"]
+
+    @pytest.mark.asyncio
+    async def test_replace_empty_list(self):
+        pool = UAPool(["ua"])
+        await pool.replace([])
+        assert len(pool) == 0
+
+
+class TestUserProfile:
+    def test_get_headers_contains_ua(self):
+        rng = random.Random(1)
+        profile = UserProfile(user_id=0, ua="TestBrowser/1.0", rng=rng)
+        headers = profile.get_headers()
+        assert headers["User-Agent"] == "TestBrowser/1.0"
+
+    def test_get_headers_with_referrer(self):
+        rng = random.Random(2)
+        profile = UserProfile(user_id=0, ua="TestBrowser/1.0", rng=rng)
+        headers = profile.get_headers(referrer="https://ref.com")
+        assert headers.get("Referer") == "https://ref.com"
+
+    def test_get_headers_no_referrer_no_referer_key(self):
+        rng = random.Random(3)
+        profile = UserProfile(user_id=0, ua="TestBrowser/1.0", rng=rng)
+        headers = profile.get_headers()
+        assert "Referer" not in headers
+
+    def test_diurnal_weight_in_range(self):
+        rng = random.Random(4)
+        profile = UserProfile(user_id=0, ua="TestBrowser/1.0", rng=rng)
+        w = profile.diurnal_weight()
+        assert 0.05 <= w <= 1.0

--- a/tests/test_structures.py
+++ b/tests/test_structures.py
@@ -1,0 +1,150 @@
+"""Unit tests for LRUSet, BoundedDict, and TTLDict."""
+
+from unittest.mock import patch
+
+import pytest
+
+from noisy_lib.structures import BoundedDict, LRUSet, TTLDict
+
+
+class TestLRUSet:
+    def test_add_and_contains(self):
+        s = LRUSet(maxsize=10)
+        s.add("a")
+        assert "a" in s
+        assert "b" not in s
+
+    def test_eviction_at_maxsize(self):
+        s = LRUSet(maxsize=3)
+        s.add("a")
+        s.add("b")
+        s.add("c")
+        s.add("d")  # evicts "a" (oldest)
+        assert "a" not in s
+        assert "d" in s
+
+    def test_lru_re_add_moves_to_end(self):
+        s = LRUSet(maxsize=3)
+        s.add("a")
+        s.add("b")
+        s.add("c")
+        s.add("a")  # re-add moves "a" to front; "b" becomes oldest
+        s.add("d")  # evicts "b"
+        assert "b" not in s
+        assert "a" in s
+        assert "d" in s
+
+    def test_discard_existing(self):
+        s = LRUSet(maxsize=10)
+        s.add("a")
+        s.discard("a")
+        assert "a" not in s
+
+    def test_discard_nonexistent_no_raise(self):
+        s = LRUSet(maxsize=10)
+        s.discard("ghost")  # must not raise
+
+    def test_len(self):
+        s = LRUSet(maxsize=10)
+        assert len(s) == 0
+        s.add("x")
+        s.add("y")
+        assert len(s) == 2
+
+    def test_maxsize_one(self):
+        s = LRUSet(maxsize=1)
+        s.add("a")
+        s.add("b")
+        assert "a" not in s
+        assert "b" in s
+        assert len(s) == 1
+
+
+class TestBoundedDict:
+    def test_set_and_get(self):
+        d = BoundedDict(maxsize=5)
+        d.set("k", "v")
+        assert d.get("k") == "v"
+
+    def test_get_missing_returns_none(self):
+        d = BoundedDict(maxsize=5)
+        assert d.get("missing") is None
+
+    def test_get_missing_returns_default(self):
+        d = BoundedDict(maxsize=5)
+        assert d.get("missing", 42) == 42
+
+    def test_eviction_at_maxsize(self):
+        d = BoundedDict(maxsize=2)
+        d.set("a", 1)
+        d.set("b", 2)
+        d.set("c", 3)  # evicts "a"
+        assert d.get("a") is None
+        assert d.get("b") == 2
+        assert d.get("c") == 3
+
+    def test_update_moves_to_front(self):
+        d = BoundedDict(maxsize=2)
+        d.set("a", 1)
+        d.set("b", 2)
+        d.set("a", 99)  # re-set moves "a" to end; "b" is now oldest
+        d.set("c", 3)   # evicts "b"
+        assert d.get("b") is None
+        assert d.get("a") == 99
+
+    def test_pop_existing(self):
+        d = BoundedDict(maxsize=5)
+        d.set("x", 10)
+        assert d.pop("x") == 10
+        assert "x" not in d
+
+    def test_pop_missing_returns_default(self):
+        d = BoundedDict(maxsize=5)
+        assert d.pop("ghost", -1) == -1
+
+    def test_contains(self):
+        d = BoundedDict(maxsize=5)
+        d.set("k", "v")
+        assert "k" in d
+        assert "missing" not in d
+
+
+class TestTTLDict:
+    def test_set_and_get(self):
+        d = TTLDict(ttl=60, maxsize=10)
+        d.set("k", "v")
+        assert d.get("k") == "v"
+
+    def test_get_missing_returns_none(self):
+        d = TTLDict(ttl=60, maxsize=10)
+        assert d.get("absent") is None
+
+    def test_get_missing_returns_default(self):
+        d = TTLDict(ttl=60, maxsize=10)
+        assert d.get("absent", 99) == 99
+
+    def test_ttl_expiry(self):
+        d = TTLDict(ttl=1.0, maxsize=10)
+        with patch("noisy_lib.structures.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            d.set("k", "v")
+            mock_time.monotonic.return_value = 102.0  # 2s elapsed > 1s TTL
+            result = d.get("k")
+        assert result is None
+
+    def test_within_ttl_not_evicted(self):
+        d = TTLDict(ttl=10.0, maxsize=10)
+        with patch("noisy_lib.structures.time") as mock_time:
+            mock_time.monotonic.return_value = 100.0
+            d.set("k", "v")
+            mock_time.monotonic.return_value = 105.0  # 5s elapsed < 10s TTL
+            result = d.get("k")
+        assert result == "v"
+
+    def test_maxsize_eviction(self):
+        d = TTLDict(ttl=60, maxsize=2)
+        d.set("a", 1)
+        d.set("b", 2)
+        d.set("c", 3)  # evicts "a"
+        assert d.get("a") is None
+        assert d.get("c") == 3

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,106 @@
+"""Unit tests for CLI argument validation."""
+
+import argparse
+import sys
+import os
+
+import pytest
+
+# Make noisy.py importable from project root
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from noisy import validate_args
+
+from noisy_lib.config import (
+    DEFAULT_CONNECTIONS_PER_HOST,
+    DEFAULT_CRUX_COUNT,
+    DEFAULT_DOMAIN_DELAY,
+    DEFAULT_KEEPALIVE_TIMEOUT,
+    DEFAULT_MAX_DEPTH,
+    DEFAULT_MAX_LINKS_PER_PAGE,
+    DEFAULT_MAX_QUEUE_SIZE,
+    DEFAULT_MAX_SLEEP,
+    DEFAULT_MIN_SLEEP,
+    DEFAULT_NUM_USERS,
+    DEFAULT_THREADS,
+    DEFAULT_TOTAL_CONNECTIONS,
+)
+
+
+def make_args(**overrides):
+    """Build a valid args namespace; override individual fields as needed."""
+    defaults = dict(
+        threads=DEFAULT_THREADS,
+        num_users=DEFAULT_NUM_USERS,
+        max_depth=DEFAULT_MAX_DEPTH,
+        min_sleep=DEFAULT_MIN_SLEEP,
+        max_sleep=DEFAULT_MAX_SLEEP,
+        domain_delay=DEFAULT_DOMAIN_DELAY,
+        total_connections=DEFAULT_TOTAL_CONNECTIONS,
+        connections_per_host=DEFAULT_CONNECTIONS_PER_HOST,
+        keepalive_timeout=DEFAULT_KEEPALIVE_TIMEOUT,
+        crux_count=DEFAULT_CRUX_COUNT,
+        max_queue_size=DEFAULT_MAX_QUEUE_SIZE,
+        max_links_per_page=DEFAULT_MAX_LINKS_PER_PAGE,
+    )
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestValidateArgs:
+    def test_valid_defaults_pass(self):
+        assert validate_args(make_args()) == []
+
+    def test_min_sleep_gt_max_sleep(self):
+        errors = validate_args(make_args(min_sleep=20.0, max_sleep=5.0))
+        assert any("min_sleep" in e for e in errors)
+
+    def test_min_sleep_equal_max_sleep_passes(self):
+        # Edge case: equal values should be allowed
+        assert validate_args(make_args(min_sleep=5.0, max_sleep=5.0)) == []
+
+    def test_threads_zero(self):
+        errors = validate_args(make_args(threads=0))
+        assert any("threads" in e for e in errors)
+
+    def test_threads_negative(self):
+        errors = validate_args(make_args(threads=-5))
+        assert any("threads" in e for e in errors)
+
+    def test_threads_positive_passes(self):
+        assert validate_args(make_args(threads=1)) == []
+
+    def test_num_users_zero(self):
+        errors = validate_args(make_args(num_users=0))
+        assert any("num_users" in e for e in errors)
+
+    def test_max_depth_zero(self):
+        errors = validate_args(make_args(max_depth=0))
+        assert any("max_depth" in e for e in errors)
+
+    def test_crux_count_zero(self):
+        errors = validate_args(make_args(crux_count=0))
+        assert any("crux_count" in e for e in errors)
+
+    def test_negative_domain_delay(self):
+        errors = validate_args(make_args(domain_delay=-1.0))
+        assert any("domain_delay" in e for e in errors)
+
+    def test_zero_domain_delay_passes(self):
+        assert validate_args(make_args(domain_delay=0.0)) == []
+
+    def test_connections_per_host_exceeds_total(self):
+        errors = validate_args(make_args(connections_per_host=50, total_connections=10))
+        assert any("connections" in e for e in errors)
+
+    def test_per_user_queue_too_small(self):
+        # 5 users, queue 9 => per-user = 1, below minimum of 10
+        errors = validate_args(make_args(max_queue_size=9, num_users=5))
+        assert any("queue" in e.lower() for e in errors)
+
+    def test_per_user_queue_exactly_10_passes(self):
+        # 1 user, queue 10 => per-user = 10
+        assert validate_args(make_args(max_queue_size=10, num_users=1)) == []
+
+    def test_multiple_errors_reported(self):
+        errors = validate_args(make_args(threads=0, min_sleep=99.0, max_sleep=1.0))
+        assert len(errors) >= 2


### PR DESCRIPTION
## Summary

- **Modular refactoring**: Split 787-line monolith `noisy.py` into 11 modules in `noisy_lib/` (each <150 lines), with clear single-responsibility boundaries and 3-line headers (IN/OUT/CALLED BY)
- **Real-time web dashboard**: FastAPI + WebSocket dashboard with 16 features: pause/resume, dark/light theme, export, alerts, live request log, top domains, error details, diurnal activity chart, domain health scoring, geo-diversity (TLD distribution), bandwidth tracking, runtime config editor, Prometheus `/metrics` endpoint, webhook notifications, stealth fingerprint score, HTTP HEAD noise worker
- **67 unit tests**: Full coverage of structures (LRUSet, BoundedDict, TTLDict), link extractor, user profiles, and CLI validation
- **Security audit fixes**: Dashboard binds `127.0.0.1` by default, validated config input with range checks, HEAD-only noise (no POST side effects), bounded rate limiter locks (50K max), webhook URL validation (http/https only), URL fragment stripping, CRUX fetch timeout (30s), 4xx no longer discards from visited cache (prevents thundering herd)
- **Start scripts**: `start.bat` (Windows) and `start.command` (macOS) for non-dev users — auto-creates venv, installs deps, launches with dashboard
- **Project docs**: CLAUDE.md (maintenance guide), LOG.md (changelog), MAP.md (dependency map)

## New dependencies

- `fastapi>=0.110` — dashboard API + WebSocket server
- `uvicorn[standard]>=0.29` — ASGI server

## Usage

```bash
python noisy.py --dashboard                          # crawl + dashboard on :8080
python noisy.py --dashboard --dashboard-port 9000    # custom port
start.bat                                            # Windows one-click
```

## Test plan

- [x] `python -m pytest tests/ -v` — 67 tests pass (<0.6s)
- [x] Dashboard loads at `http://localhost:8080` with live WebSocket updates
- [x] Pause/resume, theme toggle, config editor, export all functional
- [x] Prometheus `/metrics` endpoint returns valid text format
- [x] Existing `noisy.py` CLI works without `--dashboard` (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)